### PR TITLE
RFC: targets: added really basic skeleton for NuttX target.

### DIFF
--- a/CodeGen/nuttx/.gitignore
+++ b/CodeGen/nuttx/.gitignore
@@ -1,0 +1,2 @@
+nuttx-export
+lib/*.a

--- a/CodeGen/nuttx/README
+++ b/CodeGen/nuttx/README
@@ -1,0 +1,11 @@
+Folder for the NuttX libraries
+
+Run
+
+  make export
+
+in nuttx system source directory and extract resulting
+ZIP file there and rename it to plain nuttx-export
+directory.
+
+

--- a/CodeGen/nuttx/devices/Makefile
+++ b/CodeGen/nuttx/devices/Makefile
@@ -1,0 +1,81 @@
+all: allfiles lib install
+reduced: files lib install
+
+LIB = libpyblk.a
+RTPYINC = ../include
+SRCALL = $(wildcard *.c)
+OBJ = $(SRCALL:.c=.o)
+CWD = $(shell pwd)
+
+NUTTX_EXPORT = $(PWD)/../nuttx-export
+
+ifndef NUTTX_EXPORT
+$(warning Specify NUTTX_EXPORT)
+$(warning make_rtw NUTTX_EXPORT=/path/to/nuttx-export)
+$(error NUTTX_EXPORT not defined, cannot continue)
+endif
+
+include $(NUTTX_EXPORT)/scripts/Make.defs
+
+NUTTX_INCLUDES = -isystem $(NUTTX_EXPORT)/include
+
+SYSTEM_LIBS += --start-group $(LDLIBS) $(EXTRA_LIBS) --end-group
+ELF_MODULE_LIBS = --start-group $(EXTRA_LIBS) --end-group
+
+LDFLAGS += -L $(NUTTX_EXPORT)/libs
+
+TARGET_ARCH_FLAGS ?= $(ARCHCFLAGS) $(ARCHCPUFLAGS) \
+	-mlong-calls -fno-common -DWITHOUT_MLOCK
+
+DEFAULT_OPT_OPTS ?= $(ARCHOPTIMIZATION)
+
+ifndef OPT_OPTS
+OPT_OPTS = $(DEFAULT_OPT_OPTS)
+endif
+
+LD_SCRIPT = $(NUTTX_EXPORT)/scripts/$(LDNAME)
+
+LDFLAGS += -T $(LD_SCRIPT)
+
+LDFLAGS  += --entry=__start -nostartfiles -nodefaultlibs
+
+ELF_FILE_LDSCRIPT ?= $(wildcard $(NUTTX_EXPORT)/scripts/gnu-elf.ld)
+
+INCLUDES += $(NUTTX_INCLUDES)
+
+CFLAGS = $(TARGET_ARCH_FLAGS) $(ARCHWARNINGS) $(OPT_OPTS) $(INCLUDES)
+
+CXXFLAGS = $(TARGET_ARCH_FLAGS) $(ARCHCXXFLAGS) $(ARCHWARNINGSXX) $(OPT_OPTS) $(INCLUDES)
+
+OBJEX = $(SRC:.c=.o)
+DEFINES = -D PLOTTER_SCRIPT=\"$(CWD)/scope.py\"
+CC_FLAGS = -c $(DBG) -I$(RTPYINC) $(CFLAGS) 
+CC_FLAGS_SCP = -c $(DBG) -I$(RTPYINC) $(CFLAGS) $(DEFINES)
+CC_FLAGS_FMU = -c $(DBG) -I$(RTPYINC) $(CFLAGS) -Wall -DFMI_COSIMULATION \
+                             -DSTANDALONE_XML_PARSER -DLIBXML_STATIC \
+                              -I$(FMUDIR)/fmuinc/include -I$(FMUDIR)/fmuinc/parser -I$(FMUDIR)/fmuinc
+
+allfiles:
+
+files:
+EXCLUDE = comedi_analog_input.c comedi_analog_output.c comedi_digital_input.c comedi_digital_output.c
+SRC=$(filter-out $(EXCLUDE),$(SRCALL))
+
+scope.o: scope.c
+	$(CC) $(CC_FLAGS_SCP) $<
+
+FMUinterface.o: FMUinterface.c
+	$(CC) $(CC_FLAGS_FMU) $<
+
+%.o: %.c
+	$(CC) $(CC_FLAGS) $<
+
+lib: $(OBJ)
+	$(AR) $(LIB) $(OBJ)
+
+install:
+	mkdir -p ../lib
+	mv $(LIB) ../lib
+
+clean:
+	rm -f $(LIB) $(OBJ)

--- a/CodeGen/nuttx/devices/input.c
+++ b/CodeGen/nuttx/devices/input.c
@@ -1,0 +1,134 @@
+/*
+COPYRIGHT (C) 2016  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+double get_run_time();
+
+void step(int Flag, python_block *block)
+{
+  double t;
+  double initTime = block->realPar[0];
+  double iVal = block->realPar[1];
+  double fVal = block->realPar[2];
+  double * y;
+
+  y = (double *) block->y[0];
+  switch(Flag){
+  case CG_OUT:
+    t = get_run_time();
+    if(t<initTime) y[0] = iVal;
+    else           y[0] = fVal;
+    break;
+  case CG_INIT:
+    y[0]=0.0;
+    break;
+  case CG_END:
+    y[0]=0.0;
+    break;
+  default:
+    break;
+  }
+}
+  
+void sinus(int Flag, python_block *block)
+{
+  double t;
+  double *y = (double *) block->y[0];
+
+  double w,pi=3.1415927;
+  double Amp = block->realPar[0];
+  double Freq = block->realPar[1];
+  double Phase = block->realPar[2];
+  double Bias = block->realPar[3];
+  double Delay = block->realPar[4];
+
+  switch(Flag){
+  case CG_OUT:
+    t = get_run_time();
+    if(t<Delay) y[0] = 0.0;
+    else {
+      w=2*pi*Freq*(t-Delay)-Phase;
+      y[0]=Amp*sin(w)+Bias;
+    }
+    break;
+  case CG_INIT:
+    y[0]=0.0;
+    break;
+  case CG_END:
+    y[0]=0.0;
+    break;
+  default:
+    break;
+  }
+}
+
+void squareSignal(int Flag, python_block *block)
+{
+  double t;
+  double *y = (double *) block->y[0];
+
+  double Amp = block->realPar[0];
+  double Period = block->realPar[1];
+  double Width = block->realPar[2];
+  double Bias = block->realPar[3];
+  double Delay = block->realPar[4];
+
+  double v;
+
+  switch(Flag){
+  case CG_OUT:
+    t = get_run_time();
+    if(t<Delay) y[0]=0.0;
+    else{
+      v = (t-Delay)/Period;
+      v = (v-(int) v)*Period;
+      if (v<Width) y[0] = Amp+Bias;
+      else         y[0] = Bias;
+    }      
+    break;
+  case CG_INIT:
+    y[0]=0.0;
+    break;
+  case CG_END:
+    y[0]=0.0;
+    break;
+  default:
+    break;
+  }
+}
+
+void constant(int Flag, python_block *block)
+{
+  double *y;
+  
+  y = (double *) block->y[0];
+
+  switch(Flag){
+  case CG_OUT:
+  case CG_INIT:
+  case CG_END:
+    y[0] = block->realPar[0];
+    break;
+  default:
+    break;
+  }
+}

--- a/CodeGen/nuttx/devices/linear.c
+++ b/CodeGen/nuttx/devices/linear.c
@@ -1,0 +1,287 @@
+/*
+COPYRIGHT (C) 2016  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <matop.h>
+
+void css(int Flag, python_block *block)
+{
+  double *a, *b, *c, *d, *X;
+  int nx, ni, no;
+  double * realPar = block->realPar;
+  int * intPar    = block->intPar;
+  int iA, iB, iC, iD, iX;
+  int i;
+  double *y;
+
+  ni = intPar[1];
+  no = intPar[2];
+  nx = intPar[0];
+
+  double h = realPar[0];
+  double tmpAX[nx];
+  double tmpBU[nx];
+  double tmpCX[no];
+  double tmpDU[no];
+  double tmpY[no];
+
+  double tmpX[nx];
+  double tmpX1[nx];
+  double tmpX2[nx];
+  double tmpX3[nx];
+  double tmpX4[nx];
+
+  double tmpU[ni];
+  double *U;
+  for (i=0;i<ni;i++) {
+    U = (double *) block->u[i];
+    tmpU[i] = U[0];
+  }
+
+  switch(Flag){
+  case CG_OUT:
+    iC = intPar[5];
+    iD = intPar[6];
+    iX = intPar[7];
+    c = &realPar[iC];
+    d = &realPar[iD];
+    X = &realPar[iX];
+    matmult(c,no,nx,X,nx,1,tmpCX);
+    matmult(d,no,ni,tmpU,ni,1,tmpDU);
+    matsum(tmpCX,no,1,tmpDU,no,1,tmpY);
+    
+    for(i=0;i<no;i++){
+      y = (double *) block->y[i];
+      y[0] = tmpY[i];
+    }
+    break;
+  case CG_STUPD:
+    iA = intPar[3];
+    iB = intPar[4];
+    iX = intPar[7];
+    a = &realPar[iA];
+    b = &realPar[iB];
+    X = &realPar[iX];
+
+    /* Runga Kutta */
+    /* 1 */
+    for(i=0;i<nx;i++) tmpX[i] = X[i];
+    matmult(a,nx,nx,tmpX,nx,1,tmpAX);
+    matmult(b,nx,ni,tmpU,ni,1,tmpBU);
+    matsum(tmpAX,nx,1,tmpBU,nx,1,tmpX1);
+    for(i=0;i<nx;i++) tmpX1[i] = h*tmpX1[i];
+
+    /* 2 */
+    for(i=0;i<nx;i++) tmpX[i] = X[i]+0.5*tmpX1[i];
+    matmult(a,nx,nx,tmpX,nx,1,tmpAX);
+    matmult(b,nx,ni,tmpU,ni,1,tmpBU);
+    matsum(tmpAX,nx,1,tmpBU,nx,1,tmpX2);
+    for(i=0;i<nx;i++) tmpX2[i] = h*tmpX2[i];
+    
+    /* 3 */
+    for(i=0;i<nx;i++) tmpX[i] = X[i]+0.5*tmpX2[i];
+    matmult(a,nx,nx,tmpX,nx,1,tmpAX);
+    matmult(b,nx,ni,tmpU,ni,1,tmpBU);
+    matsum(tmpAX,nx,1,tmpBU,nx,1,tmpX3);
+    for(i=0;i<nx;i++) tmpX3[i] = h*tmpX3[i];
+    
+    /* 4 */
+    for(i=0;i<nx;i++) tmpX[i] = X[i]+tmpX3[i];
+    matmult(a,nx,nx,tmpX,nx,1,tmpAX);
+    matmult(b,nx,ni,tmpU,ni,1,tmpBU);
+    matsum(tmpAX,nx,1,tmpBU,nx,1,tmpX4);
+    for(i=0;i<nx;i++) tmpX4[i] = h*tmpX4[i];
+    
+    for(i=0;i<nx;i++) X[i] = X[i] + tmpX1[i]/6 + tmpX2[i]/3 + tmpX3[i]/3 + tmpX4[i]/6;
+    break;
+  case CG_INIT:
+  case CG_END:
+    break;
+  default:
+    break;
+  }
+}
+  
+void integral(int Flag, python_block *block)
+{
+  double * realPar = block->realPar;
+  double *y;
+
+  double h = realPar[0];
+  double *U = block->u[0];
+
+  switch(Flag){
+  case CG_OUT:
+    y = (double *) block->y[0];
+    y[0] = realPar[1];
+    break;
+
+  case CG_STUPD:
+    /* Runga Kutta */
+    realPar[1] = realPar[1] + U[0]*h;
+    break;
+  case CG_INIT:
+  case CG_END:
+    break;
+  default:
+    break;
+  }
+}
+  
+void dss(int Flag, python_block *block)
+{
+  double *a, *b, *c, *d, *X;
+  int nx, ni, no;
+  double * realPar = block->realPar;
+  int * intPar    = block->intPar;
+  int iA, iB, iC, iD, iX;
+  int i;
+  double *y;
+
+  ni = intPar[1];
+  no = intPar[2];
+  nx = intPar[0];
+
+  double tmpAX[nx];
+  double tmpBU[nx];
+  double tmpCX[no];
+  double tmpDU[no];
+  double tmpY[no];
+
+  double tmpU[ni];
+  double *U;
+  for (i=0;i<ni;i++) {
+    U = (double *) block->u[i];
+    tmpU[i] = U[0];
+  }
+
+  switch(Flag){
+  case CG_OUT:
+    iC = intPar[5];
+    iD = intPar[6];
+    iX = intPar[7];
+    c = &realPar[iC];
+    d = &realPar[iD];
+    X = &realPar[iX];
+    matmult(c,no,nx,X,nx,1,tmpCX);
+    matmult(d,no,ni,tmpU,ni,1,tmpDU);
+    matsum(tmpCX,no,1,tmpDU,no,1,tmpY);
+    for(i=0;i<no;i++){
+      y = (double *) block->y[i];
+      y[0] = tmpY[i];
+    }
+    break;
+  case CG_STUPD:
+    iA = intPar[3];
+    iB = intPar[4];
+    iX = intPar[7];
+    a = &realPar[iA];
+    b = &realPar[iB];
+    X = &realPar[iX];
+    matmult(a,nx,nx,X,nx,1,tmpAX);
+    matmult(b,nx,ni,tmpU,ni,1,tmpBU);
+    matsum(tmpAX,nx,1,tmpBU,nx,1,X);
+    break;
+  case CG_INIT:
+  case CG_END:
+    break;
+  default:
+    break;
+  }
+}
+  
+void unitDelay(int Flag, python_block *block)
+{
+  double * realPar = block->realPar;
+  double *y = block->y[0];
+  double *u = block->u[0];
+
+  switch(Flag){
+  case CG_OUT:
+    y[0] = realPar[0];
+    break;
+
+  case CG_STUPD:
+    realPar[0] = u[0];
+    break;
+  case CG_INIT:
+  case CG_END:
+    break;
+  default:
+    break;
+  }
+}
+  
+void mxmult(int Flag, python_block *block)
+{
+
+    /* blk = RCPblk('mxmult',pin,pout,0,realPar,[n,m]) */
+
+  int i;
+  double *y;
+  double *u;
+
+  int nin = block->intPar[1];
+  int nout = block->intPar[0];
+  double tmpY[nout];
+  double tmpU[nin];
+
+  double * gain = block->realPar;
+
+  switch(Flag){
+  case CG_OUT:
+  case CG_INIT:
+  case CG_END:
+    for (i=0; i<nin; i++) {
+      u = block->u[i];
+      tmpU[i]=u[0];
+    }
+    matmult(gain,nout,nin,tmpU,nin,1,tmpY);
+    for(i=0; i<nout; i++){
+      y = block->y[i];
+      y[0] = tmpY[i];
+    }
+    break;
+  default:
+    break;
+  }
+}
+  
+void sum(int Flag, python_block *block)
+{
+  int i;
+  double *y;
+  double *u;
+  
+  y = (double *) block->y[0];
+
+  switch(Flag){
+  case CG_OUT:
+  case CG_INIT:
+  case CG_END:
+    y[0] = 0.0;
+    for (i=0;i<block->nin;i++){
+      u = (double *) block->u[i];
+      y[0] += block->realPar[i]*u[0];
+    }
+    break;
+  default:
+    break;
+  }
+}
+  

--- a/CodeGen/nuttx/devices/matop.c
+++ b/CodeGen/nuttx/devices/matop.c
@@ -1,0 +1,52 @@
+/*
+COPYRIGHT (C) 2016  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <stdio.h>
+
+int matmult(double *a, int na, int ma, double *b, int nb, int mb, double* c)
+{
+  int i, j, k;
+
+  if (ma!=nb){
+    fprintf(stderr,"MATMULT: A and B matrices: Incompatible sizes\n");
+    return -1;
+  }
+
+  for(i=0;i<na;i++){
+    for(j=0;j<mb;j++){
+      c[i*mb+j] = 0;
+      for(k=0;k<ma;k++)
+	c[i*mb+j] += a[i*ma+k]*b[k*mb+j];
+    }
+  }
+  return 0;
+}
+
+int matsum(double *a, int na, int ma, double *b, int nb, int mb, double* c)
+{
+  int i;
+
+  if ((na != nb) || (ma != mb)){
+    fprintf(stderr,"MATSUM: A and B matrices: Incompatible sizes\n");
+    return -1;
+  }
+
+  for(i=0; i<na*ma; i++) c[i] = a[i]+b[i];
+  return 0;
+}
+

--- a/CodeGen/nuttx/devices/toNull.c
+++ b/CodeGen/nuttx/devices/toNull.c
@@ -1,0 +1,25 @@
+/*
+COPYRIGHT (C) 2009  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+
+void toNull(int flag, python_block *block)
+{
+}
+
+

--- a/CodeGen/nuttx/include/matop.h
+++ b/CodeGen/nuttx/include/matop.h
@@ -1,0 +1,2 @@
+int matmult(double *a, int na, int ma, double *b, int nb, int mb, double* c);
+int matsum(double *a, int na, int ma, double *b, int nb, int mb, double* c);

--- a/CodeGen/nuttx/include/pyblock.h
+++ b/CodeGen/nuttx/include/pyblock.h
@@ -1,0 +1,18 @@
+#define CG_INIT  1
+#define CG_OUT   2
+#define CG_STUPD 3
+#define CG_END   4
+
+typedef struct {
+  int nin;             /* Number of inputs */
+  int nout;            /* Number of outputs */
+  int * dimIn;       /* Port signal dimension */
+  int * dimOut;      /* Port signal dimension */
+  int *nx;             /* Cont. and Discr states */
+  void **u;            /* inputs */
+  void **y;            /* outputs */
+  double *realPar;     /* Real parameters */
+  int *intPar;         /* Int parameters */
+  char * str;          /* String */
+  void * ptrPar;       /* Generic pointer */
+}python_block;

--- a/CodeGen/templates/nuttx.tmf
+++ b/CodeGen/templates/nuttx.tmf
@@ -1,0 +1,79 @@
+MODEL = $$MODEL$$
+all:  ../$(MODEL).elf ../$(MODEL)
+
+
+PYCODEGEN = $(PYSUPSICTRL)/CodeGen
+MAINDIR = $(PYCODEGEN)/src
+LIBDIR  = $(PYCODEGEN)/nuttx/lib
+INCDIR  = $(PYCODEGEN)/nuttx/include
+NUTTX_EXPORT = $(PYCODEGEN)/nuttx/nuttx-export
+
+RM = rm -f
+FILES_TO_CLEAN = *.o $(MODEL) $(MODEL).elf
+
+ifndef NUTTX_EXPORT
+$(warning Specify NUTTX_EXPORT)
+$(warning make_rtw NUTTX_EXPORT=/path/to/nuttx-export)
+$(error NUTTX_EXPORT not defined, cannot continue)
+endif
+
+include $(NUTTX_EXPORT)/scripts/Make.defs
+
+NUTTX_INCLUDES = -isystem $(NUTTX_EXPORT)/include
+
+SYSTEM_LIBS += --start-group $(LDLIBS) $(EXTRA_LIBS) --end-group
+ELF_MODULE_LIBS = --start-group $(EXTRA_LIBS) --end-group
+
+LDFLAGS += -L $(NUTTX_EXPORT)/libs
+
+TARGET_ARCH_FLAGS ?= $(ARCHCFLAGS) $(ARCHCPUFLAGS) \
+	-mlong-calls -fno-common -DWITHOUT_MLOCK
+
+DEFAULT_OPT_OPTS ?= $(ARCHOPTIMIZATION)
+
+ifndef OPT_OPTS
+OPT_OPTS = $(DEFAULT_OPT_OPTS)
+endif
+
+LD_SCRIPT = $(NUTTX_EXPORT)/scripts/$(LDNAME)
+
+LDFLAGS += -T $(LD_SCRIPT)
+
+LDFLAGS  += --entry=__start -nostartfiles -nodefaultlibs
+
+ELF_FILE_LDSCRIPT ?= $(wildcard $(NUTTX_EXPORT)/scripts/gnu-elf.ld)
+
+MAIN = nuttx_main
+ADD_FILES = $$ADD_FILES$$
+
+OBJSSTAN = $(MAIN).o $(MODEL).o $(ADD_FILES)
+
+INCLUDES += -I$(INCDIR) $(NUTTX_INCLUDES)
+
+CFLAGS = $(TARGET_ARCH_FLAGS) $(ARCHWARNINGS) $(OPT_OPTS) $(INCLUDES) -DMODEL=$(MODEL)
+
+CXXFLAGS = $(TARGET_ARCH_FLAGS) $(ARCHCXXFLAGS) $(ARCHWARNINGSXX) $(OPT_OPTS) $(INCLUDES) -DMODEL=$(MODEL)
+
+LIB = $(LIBDIR)/libpyblk.a
+
+$(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
+	cp $< .
+
+%.o: ../%.c
+	$(CC) -c -o $@ $(CFLAGS) $<
+
+../$(MODEL).elf: $(OBJSSTAN) $(LIB)
+	[ ! -e  $(ELF_FILE_LDSCRIPT) ] || \
+	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) -o $@ \
+	  -r -e main -T $(ELF_FILE_LDSCRIPT) \
+	  -Map $(1).elf.map \
+	  $(OBJSSTAN) $(LIB) $(LIBS) $(ELF_MODULE_LIBS)
+	@echo "### Created ELF loadable file: $(MODEL).elf"
+
+../$(MODEL): $(OBJSSTAN) $(LIB)
+	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) \
+	  -o $@  $(OBJSSTAN) $(LIB) $(SYSTEM_LIBS)
+	@echo "### Created executable: $(MODEL)"
+
+clean:
+	@$(RM) $(FILES_TO_CLEAN)


### PR DESCRIPTION
The model with PulseGenerator, Gain and NULL blocks
can be build and load as ELF file into running NuttX
system.

To build model, nuttx-export archive has to be extracted
and renamed to CodeGen/nuttx/nuttx-export .

NuttX project:
  https://github.com/apache/incubator-nuttx

This pull request is intended mostly for review, discussion
and probably needs more work to be usable.