### PR TITLE
Update pysimCoder launch script to other users accounts and setup links.

### DIFF
--- a/pysimCoder
+++ b/pysimCoder
@@ -1,11 +1,35 @@
-export PYSUPSICTRL=/home/bucher/CACSD/pysimCoder
+#!/bin/sh
+
+export PYSUPSICTRL="$( cd "$(dirname "$0")" ; pwd )"
 export PYEDITOR=emacs
-export PYTHONPATH=/home/bucher/CACSD/pysimCoder/resources/blocks/rcpBlk
+
+if [ -n "$PYTHONPATH" ] ; then
+    PYTHONPATH=":$PYTHONPATH"
+fi
+
+export PYTHONPATH="$PYSUPSICTRL/resources/blocks/rcpBlk$PYTHONPATH"
+
+PYSUPSICTRL_LINKS="$HOME/Documents/pysupsictrl/toolbox"
+if [ "$1" = '-s' ] ; then
+    shift
+    mkdir -p "$PYSUPSICTRL_LINKS"
+    rm -f "$PYSUPSICTRL_LINKS/supsisim"
+    ln -s "$PYSUPSICTRL/toolbox/supsisim/src" "$PYSUPSICTRL_LINKS/supsisim"
+    rm -f "$PYSUPSICTRL_LINKS/supsictrl"
+    ln -s "$PYSUPSICTRL/toolbox/supsictrl/src" "$PYSUPSICTRL_LINKS/supsictrl"
+fi
+
+if [ -e "$PYSUPSICTRL_LINKS" ] ; then
+    export PYTHONPATH="$PYSUPSICTRL_LINKS:$PYTHONPATH"
+fi
 
 if [ -t 0 -a -t 1 ]
 then
-    pysimCoder.py $1
+    /usr/bin/python3 "$PYSUPSICTRL/BlockEditor/pysimCoder.py" "$@"
 else
-    pysimCoder.py $1 > /tmp/pysimCoder.log
+    /usr/bin/python3 "$PYSUPSICTRL/BlockEditor/pysimCoder.py" > /tmp/pysimCoder.log "$@"
 fi
 
+if [ $? -ne 0 ] ; then
+   echo >&2 "consider to run $0 with -s argument to setup links in $PYSUPSICTRL_LINKS"
+fi


### PR DESCRIPTION
When pysimCoder is run from GIT without running

  python3 setup.py build
  sudo python3 setup.py install

in pysimCoder/toolbox/supsictrl and pysimCoder/toolbox/supsisim
then required libraries cannot be found. Inform user that
such problem can be reslved by running with -s option
which setups required links in

  $HOME/Documents/pysupsictrl/toolbox

and adjusts PYTHONPATH.