### PR TITLE
Fix dependency list in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CURDIR = $(shell pwd)
 CWD = $(shell pwd)
 PYCTL = export PYSUPSICTRL=$(CWD)
 
-addfiles: control, slycot
+addfiles: control slycot
 
 control:
 	git clone https://github.com/python-control/python-control.git


### PR DESCRIPTION
Doesn't work with a comma for me (GNU Make 4.3)