### PR TITLE
NuttX: Added support for SocketCAN

### DIFF
--- a/CodeGen/nuttx/devices/Makefile
+++ b/CodeGen/nuttx/devices/Makefile
@@ -45,7 +45,15 @@ ifeq ($(CONFIG_SENSORS_QENCODER),y)
 SRCALL += nuttxENC.c
 endif
 
+have_can =
 ifeq ($(CONFIG_CAN),y)
+	have_can = yes
+endif
+ifeq ($(CONFIG_NET_CAN),y)
+	have_can = yes
+endif
+
+ifdef have_can
 SRCALL += canopen.c \
 baumer_encoder.c \
 maxon_encoder.c  \


### PR DESCRIPTION
This commit introduces SocketCAN support for NuttX. New functions `socketCAN_open(char * dev)` and `socketCAN_saveMsg(struct can_frame m)` were added to support different open proccess and different NuttX structure of message, the overall princip remains the same (functions `canOpenTH(char * dev)` and `sendMsg(uint16_t ID, uint8_t DATA[], int len)` are called from block´s source code). File `canopen.c` now can support both characteristic device dev/can0 and socketcan.
 
There are also few unused functions like `rcvMsg(uint8_t DATA[], int timeout)`, `rcvMsgCob(int cob, uint8_t DATA[], int timeout)` and `canOpen(char * dev)`. I am not sure whether they should be removed as they do not support real time receive or whether they can have some usage.

SocketCAN communication was tested on existing blocks.