### PR TITLE
NuttX: Updated PWM block to support multiple channels

### DIFF
--- a/resources/blocks/blocks/NuttX/nuttx_PWM.xblk
+++ b/resources/blocks/blocks/NuttX/nuttx_PWM.xblk
@@ -1,1 +1,1 @@
-{"lib": "NuttX", "name": "PWM", "ip": 1, "op": 0, "stin": 0, "stout": 0, "icon": "PWM", "params": "nuttx_PWMBlk|Port:'/dev/pwm2'|channel: 1| PWM freq [Hz]:10000|Umin [V]:0.0|Umax [V]:100.0"}
+{"lib": "NuttX", "name": "PWM", "ip": 1, "op": 0, "stin": 1, "stout": 0, "icon": "PWM", "params": "nuttx_PWMBlk|Port:'/dev/pwm2'|channels: [1]|PWM freq [Hz]:10000|Umin [V]:0.0|Umax [V]:100.0"}

--- a/resources/blocks/rcpBlk/NuttX/nuttx_PWMBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_PWMBlk.py
@@ -20,5 +20,8 @@ def nuttx_PWMBlk(pin, port, ch, freq, umin, umax):
 
     """
 
-    blk = RCPblk('nuttx_PWM', pin, [], [0,0], 1, [umin, umax, freq], [ch], port)
+    if(size(pin) != size(ch)):
+        raise ValueError("Number of inputs (%i) should match number of channels (%i)" % (size(pin),size(ch)))
+
+    blk = RCPblk('nuttx_PWM', pin, [], [0,0], 1, [umin, umax, freq], ch, port)
     return blk

--- a/resources/blocks/rcpBlk/help/nuttx_PWMBlk.hlp
+++ b/resources/blocks/rcpBlk/help/nuttx_PWMBlk.hlp
@@ -1,6 +1,9 @@
 Parameters
 Port        :  device name
-channel: 1..4   PA6 PA7 PB1 PB2
+channel: 1..4 (array)
 Frequency: PWM freq in Hz
 Umin [V]: minimal value (umin -> 0%)
 Umax [V] : maximal value (umax -> 100%)
+
+Can have multiple inputs to support
+multiple channel PWM.


### PR DESCRIPTION
Updates PWM block for NuttX to support multiple channel PWM. Tested with Teensy 4.1 board with iMXRT MCU and NuttX.