### PR TITLE
NuttX: Fixed problems when using multiple same blocks

### DIFF
--- a/CodeGen/nuttx/devices/nuttx_Adc.c
+++ b/CodeGen/nuttx/devices/nuttx_Adc.c
@@ -33,10 +33,11 @@
 #define NCHANNELS 3          /* the same as in board/xxxx_adc.c  */
 #define ADC_RES 4095
 
-static int fd;
-
 static void init(python_block *block)
 {
+  int * intPar = block->intPar;
+  int fd = intPar[1];
+
   if(fd==0){
     fd = open(block->str, O_RDONLY);
     if(fd<0) {
@@ -44,6 +45,8 @@ static void init(python_block *block)
       exit(1);
     }
   }
+
+  intPar[1] = fd;
 }
 
 static void inout(python_block *block)
@@ -53,6 +56,7 @@ static void inout(python_block *block)
   double *y = block->y[0];
   int ret;
   int ch = intPar[0];
+  int fd = intPar[1];
   int readsize = NCHANNELS*sizeof(struct adc_msg_s);
   int nbytes;
   

--- a/CodeGen/nuttx/devices/nuttx_DAC.c
+++ b/CodeGen/nuttx/devices/nuttx_DAC.c
@@ -31,9 +31,6 @@
 
 #include <nuttx/analog/dac.h>
 
-static int fd;
-static bool initialized = false;
-
 /****************************************************************************
  * Name: init
  *
@@ -44,7 +41,10 @@ static bool initialized = false;
 
 static void init(python_block *block)
 {
-  if (!initialized)
+  int * intPar = block->intPar;
+  int fd = intPar[1];
+
+  if (fd == 0)
     {
       fd = open(block->str, O_WRONLY | O_NONBLOCK);
       if (fd < 0)
@@ -52,9 +52,9 @@ static void init(python_block *block)
           fprintf(stderr, "Error opening device: %s\n", block->str);
           exit(1);
         }
-
-      initialized = true;
     }
+
+  intPar[1] = fd;
 }
 
 /****************************************************************************
@@ -74,6 +74,7 @@ static void inout(python_block *block)
 
   int data  = (int)u[0];
   int channel = intPar[0];
+  int fd = intPar[1];
 
   msgs[0].am_channel = channel;
   msgs[0].am_data = data;

--- a/resources/blocks/rcpBlk/NuttX/nuttx_AdcBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_AdcBlk.py
@@ -18,5 +18,5 @@ def nuttx_AdcBlk(pout, devname, ch, umin, umax):
 
     """
 
-    blk = RCPblk('nuttx_Adc', [], pout, [0,0], 0, [umin, umax], [ch-1], devname)
+    blk = RCPblk('nuttx_Adc', [], pout, [0,0], 0, [umin, umax], [ch-1, 0], devname)
     return blk

--- a/resources/blocks/rcpBlk/NuttX/nuttx_DACBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_DACBlk.py
@@ -18,5 +18,5 @@ def nuttx_DACBlk(pin, port, channel):
 
     """
 
-    blk = RCPblk('nuttx_DAC', pin, [], [0,0], 1, [], [channel], port)
+    blk = RCPblk('nuttx_DAC', pin, [], [0,0], 1, [], [channel, 0], port)
     return blk

--- a/resources/blocks/rcpBlk/NuttX/nuttx_PWMBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_PWMBlk.py
@@ -23,5 +23,7 @@ def nuttx_PWMBlk(pin, port, ch, freq, umin, umax):
     if(size(pin) != size(ch)):
         raise ValueError("Number of inputs (%i) should match number of channels (%i)" % (size(pin),size(ch)))
 
+    ch.append(0)
+
     blk = RCPblk('nuttx_PWM', pin, [], [0,0], 1, [umin, umax, freq], ch, port)
     return blk


### PR DESCRIPTION
Global static variables (mostly file descriptors and structures) were causing problems when multiple blocks of the same driver were used. This change should fix all of those global variables in NuttX subfolder. Integer parameter or pointer parameter was used to get file descriptors and structures to the functions based on some drivers without those problems (ENC or GPIO).