### PR TITLE
Added discrete PID block and TCP Socket TX block

### DIFF
--- a/CodeGen/Common/common_dev/discretePID.c
+++ b/CodeGen/Common/common_dev/discretePID.c
@@ -1,0 +1,125 @@
+/*
+COPYRIGHT (C) 2021  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/****************************************************************************
+ * Name: init
+ *
+ * Description:
+ *   Not used.
+ *
+ ****************************************************************************/
+
+static void init(python_block *block)
+{
+}
+
+/****************************************************************************
+ * Name: inout
+ *
+ * Description:
+ *   Compute the output signal.
+ *
+ ****************************************************************************/
+
+static void inout(python_block *block)
+{
+
+  double *u = block->u[0];
+  double *realPar = block->realPar;
+  double *y = block->y[0];
+
+  double error = u[0];
+  double Kp = realPar[0];
+  double Ki = realPar[1];
+  double Kd = realPar[2];
+  double min_val = realPar[3];
+  double max_val = realPar[4];
+
+  double error_last = realPar[5];
+  double integral_sum = realPar[6];
+
+  /* Set integral sum */
+
+  if (Ki == 0)
+    {
+      integral_sum = 0;
+    }
+  else
+    {
+      integral_sum += error * Ki;
+    }
+
+  /* Compute the output value */
+
+  double action = Kp * error + integral_sum + Kd * (error - error_last);
+  error_last = error;
+
+  /* Anti-windup protection */
+
+  if (action > max_val)
+    {
+      integral_sum = integral_sum - (action - max_val);
+      action = max_val;
+    }
+  else if (action < min_val)
+    {
+      integral_sum = integral_sum - (-action + min_val);
+      action = min_val;
+    }
+
+  realPar[5] = error_last;
+  realPar[6] = integral_sum;
+  y[0] = action;
+}
+
+/****************************************************************************
+ * Name: end
+ *
+ * Description:
+ *   Not used.
+ *
+ ****************************************************************************/
+
+static void end(python_block *block)
+{
+}
+
+/****************************************************************************
+ * Name: discretePID
+ *
+ * Description:
+ *   Call needed function based on input flag.
+ *
+ ****************************************************************************/
+
+void discretePID(int flag, python_block *block)
+{
+  if (flag==CG_OUT){          /* get input */
+    inout(block);
+  }
+  else if (flag==CG_END){     /* termination */
+    end(block);
+  }
+  else if (flag ==CG_INIT){   /* initialisation */
+    init(block);
+  }
+}

--- a/CodeGen/nuttx/devices/Makefile
+++ b/CodeGen/nuttx/devices/Makefile
@@ -21,8 +21,7 @@ include $(NUTTX_EXPORT)/.config
 
 SRCALL = $(wildcard $(COMMON_DIR)/common_dev/*.c)
 SRCALL += toFile.c \
-		   serialOut.c \
-		   UDPsocketTx.c
+		   serialOut.c
 
 ifeq ($(CONFIG_ADC),y)
 SRCALL += nuttx_Adc.c
@@ -47,6 +46,14 @@ endif
 
 ifeq ($(CONFIG_SENSORS_DHTXX),y)
 SRCALL += sensors/nuttxDHTXX.c
+endif
+
+ifeq ($(CONFIG_NET_TCP),y)
+SRCALL += TCPsocketTx.c
+endif
+
+ifeq ($(CONFIG_NET_UDP),y)
+SRCALL += UDPsocketTx.c
 endif
 
 have_can =

--- a/CodeGen/nuttx/devices/TCPsocketTx.c
+++ b/CodeGen/nuttx/devices/TCPsocketTx.c
@@ -1,0 +1,128 @@
+/*
+  COPYRIGHT (C) 2021 Roberto Bucher (roberto.bucher@supsi.ch)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <math.h>
+
+/****************************************************************************
+ * Name: init
+ *
+ * Description:
+ *   Connect the socket.
+ *
+ ****************************************************************************/
+
+static void init(python_block *block)
+{
+  int * intPar    = block->intPar;
+  struct sockaddr_in server;
+  socklen_t addrlen = sizeof(struct sockaddr_in);
+
+  char * IPbuf;
+  struct hostent *he;
+
+  if ((he = gethostbyname(block->str)) == NULL) exit(1);
+  IPbuf =  inet_ntoa(*((struct in_addr*) he->h_addr_list[0]));
+
+  int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+  if (sockfd < 0)
+    {
+      printf("client socket failure %d\n", errno);
+      exit(1);
+    }
+  intPar[1] = sockfd;
+
+  server.sin_family      = AF_INET;
+  server.sin_port        = htons(block->intPar[0]);
+  server.sin_addr.s_addr = inet_addr(IPbuf);
+
+  if (connect(sockfd, (struct sockaddr *) &server, addrlen) < 0)
+    {
+      printf("client: connect failure: %d\n", errno);
+      close(sockfd);
+      exit(1);
+    }
+}
+
+/****************************************************************************
+ * Name: inout
+ *
+ * Description:
+ *   Send data over TCP.
+ *
+ ****************************************************************************/
+
+static void inout(python_block *block)
+{
+  int i;
+  int * intPar = block->intPar;
+  double *u;
+  double data[block->nin];
+
+  int s = intPar[1];
+
+  for(i=0;i<block->nin;i++)
+    {
+      u = block->u[i];
+      data[i] = u[0];
+    }
+
+  send(s, data, sizeof(data) , 0);
+}
+
+/****************************************************************************
+ * Name: init
+ *
+ * Description:
+ *   Close the socket.
+ *
+ ****************************************************************************/
+
+static void end(python_block *block)
+{
+  int * intPar    = block->intPar;
+
+  close(intPar[1]);
+}
+
+/****************************************************************************
+ * Name: TCPsocketTx
+ *
+ * Description:
+ *   Call needed function based on input flag.
+ *
+ ****************************************************************************/
+
+void TCPsocketTx(int flag, python_block *block)
+{
+  if (flag==CG_OUT){          /* get input */
+    inout(block);
+  }
+  else if (flag==CG_END){     /* termination */
+    end(block);
+  }
+  else if (flag ==CG_INIT){   /* initialisation */
+    init(block);
+  }
+}

--- a/resources/blocks/Icons/PID.svg
+++ b/resources/blocks/Icons/PID.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="PID.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="32.40678"
+     inkscape:cy="24"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="5.5254235"
+     y="27.677965"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       id="tspan3363"
+       x="5.5254235"
+       y="27.677965"
+       style="font-size:15px;line-height:1.25;font-family:sans-serif">   PID</tspan></text>
+</svg>

--- a/resources/blocks/Icons/TCPSOCKET.svg
+++ b/resources/blocks/Icons/TCPSOCKET.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="TCPSOCKET.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="-30.542372"
+     inkscape:cy="-16.400774"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="18.508474"
+     y="28.084745"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       id="tspan3363"
+       x="20.89617"
+       y="28.084745"
+       style="font-size:15px;line-height:1.25;font-family:sans-serif"> </tspan></text>
+  <image
+     y="4"
+     x="6.4406776"
+     id="image929"
+     xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz AAAFMQAABTEBt+0oUgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAddSURB VHja1ZlrSFVZFMfX8ZWPfOdYms6QV8vHlEaGj2kYCCKwaLAa61MUUYP2gAbqU1MSPYSiDw4NCRXR gxAGCz9MTmkTNI6Gmm8bX3UtzUe+vXp9XO/818Z953awjDHPtQUL1zkcz/2tvddae+19FLPZTJ+z ONAcS3V1dY6dnZ2wFQhsZcqWt+h9IgfXPGVMTk6a5TXs36OiorLm3AEXF5fv/fz8yMoJa5X3PgSv toU2NzcP4laWHc2xGI1GngW6du0ajY6O0tjY2Ds6MTEh1GQySbXcGx8flyr+t7Kykq5evSreOTw8 3KVJCLH4+PjQ+vXrSS1y5KXNap2T6vxctGgRbdiwQdscYPH19RVwMwmAZ3wPnuFc0NYBNaR0RgLn 5ORQbW0tSUlNTSVvb2+1Y9LWfgbkj6rBs7OzqaCggLq6uqi1tZWkvHjxQjx7+fLlD8FrPwMA4IQW CuFKYrEdHP5DqampIZZbt25Zqs7OnTvlO2QYaT8DLKWlpXTjxg1hq8HVkpWVZbF37NhhmxmQIyaF 1wN7e3s237suYHTV/8e2tdrOAUDyqEubHZIqn5dOSJ3WAdy3jQOoLtIBhmZbOmCd5HJRE6A6nW7+ zMDAwABDy1BiW15bhxDD8wrMfznZp5sJ2+YAq6Ojo4B3cnKSTvCzEp6vRUsRHBxs/R7bzoCHhweD Czhf70nYZlqwgPBXgTqgP1Kmeh8RPtTd60B6vV498trngLSHhoYso/1VQB87AwcmoAtgT1D/oBON jk2QcWSUnJ0M1DfgZZ20tssB2ULIxGW7rctDhI+zszMtXLhQqHHCRIOGQXSbCk2aFFm1rMHntAop UDk81j9mSdDNmzfT1q1bp+1G1Quf9bXBYJD35yaJr1+/HuLl5ZXW0dFxbN++feMESU9Pt0tKSrL+ YbknUIHPvILDnrtm7ubNm7qYmJinoaGhXoWFhYmHDh36dunSpV9HRERkAnhaGICr76vvzQjPMusd 2ZUrV3TYmxZDvXt6epSQkJC12HSUQAu2b98eNzg4KFrle/fuqZsxVrZnvCftpqYm+Z7ZOyDho6Oj i1euXOnz5s0bER4iuWIoanHEYneCbNy4UVSe2NjYGZJ8elXv7NatWzf7EJLwQUFBFTBdJTxLmUMZ 6Sf1FKfEEaohOeEXUlJSeNMiFig3NzearWCm2TmF7f91LnTp0iUdQqViyZIlrniZKIX+/v702PiY 9GY9HQg9QJ3dfpRXS3TgO+GEGM3z588XHT16NMEMsdm5EMMvW7bMAt/X10f9/f1UXFVM3Wu7Kdk9 marqzPRXq5mSYxRyGhsmMk7S45KSwSdPnhyU8DZx4OLFizpUlnI1fHl5OY2MjFBKWAq1j/pRfpMj JUV2UbgnwqWikobRPlRVVemRzFX0iYVD6KPhw8PDywMCAtzU8DijoZMnTxIco7+fllHvpB9FeA6R N3oYB9zrcHcXK/Ddu3efouR+U1JSMk6fSOw+Fn7FihUzwrPEr11NrsYmcmtspBEkLMNDRM+zd+/e WFSsDIJo5sC5c+d0y5cvLw8MDJwRnoUr0p07dygXpwyGgACCcKMmnsnNze3F6P+imQOnT5/+EiNW jlVVDS96kxMnTqjh2SFRKh2h7e3tFvjbt293nzp1Kg7Hg82aJTFqezCm3lnCYzfFixI7wVC8sKjh RUeJxY1cXV35ObGbevDgQU9GRkZCXV1dA0E0mQEFgkPUkEePHmXi0MkEeDHquCf2qG1tbXTmzBm+ ZlsNz6fSfM3VZ/js2bOJgK8niGZVCA1ZCA5TaxTItm3bHAGivHr1Smzx5I6ooaGBZ0KcrLkjWdXw OLQaxuK1GrPwD0nRagYA3Pr27dtsbCbsHz58qDCcp6ennB1RVdDAEdpnhp925NXwms2AAjl8+HAp Nt4BAHNHLLuijxFgCCcGZQe4heD6ztfThU3M69evLWGj+QwA2BlfVvwB6YJKxBttUVUQRpzQDM9O iIpjDY8qY0A+CHibfSMzQ9C2JmJ0GzALvgA3QxXsuAgdKBUVFbGDFBkZKcAlfEVFhQGlMgY5oao2 Gs8Af4tbtWrVz5s2bfJCfHOfo2C0zbwx4ZBbs2YN3b9/34zyapLwWBsEfGdnp4TX3gEJn5aWdmHL li0HES729fX1hHDgRFXwhcScn58/jMQ2JSYmjuO7VybKq+nZs2eG48ePR2sKr05iCb9///4LODUQ 8CiDcgEzYSPeFx8f74tWoAOL1h/Iix/QHv+IdqKpt7e3BaoniM0cYHg0Wxewjz2IEX8HvqWlJRM1 Pz0hIaHQCMFXlQSU1EBUp2ZVf28bBxTInj17UvER4RhGPsgaHsd6mRj1n/jbMjtJELZpnogDw+/e vfs77FujAN8EeHvAB2B0TS9fvswsKysT8GrweePArl27/DDybgibRsDbAZ4YvrGx8TfUdAk/b0XJ y8tTAB8G+DDAhwFeh3ivxmr667yFV+fAkSNHlCn40OfPnxtQ7//UODlnf3qcnJysYOf1hXTqc9F/ AXHzHowT7gvKAAAAAElFTkSuQmCC "
+     preserveAspectRatio="none"
+     height="35"
+     width="35" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:9px;font-family:Sans;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32"
+     y="47"
+     id="text817"><tspan
+       sodipodi:role="line"
+       x="32"
+       y="47"
+       id="tspan152">tcp sock</tspan></text>
+</svg>

--- a/resources/blocks/blocks/Communication/TCPsocketTX.xblk
+++ b/resources/blocks/blocks/Communication/TCPsocketTX.xblk
@@ -1,0 +1,1 @@
+{"lib": "Communication", "name": "TCPsocketTX", "ip": 1, "op": 0, "stin": 1, "stout": 0, "icon": "TCPSOCKET", "params": "TCPsocketTxBlk|IP Addr:'127.0.0.1'|Port:5000"}

--- a/resources/blocks/blocks/linear/DiscretePID.xblk
+++ b/resources/blocks/blocks/linear/DiscretePID.xblk
@@ -1,0 +1,1 @@
+{"lib": "linear", "name": "Discrete PID", "ip": 1, "op": 1, "stin": 0, "stout": 0, "icon": "PID", "params": "discretePIDBlk|Proportional gain: 1|Integral gain: 1|Derivative gain: 1|Min value: -3.3|Max value: 3.3"}

--- a/resources/blocks/rcpBlk/Communication/TCPsocketTxBlk.py
+++ b/resources/blocks/rcpBlk/Communication/TCPsocketTxBlk.py
@@ -1,0 +1,23 @@
+
+from supsisim.RCPblk import RCPblk
+from scipy import size
+
+def TCPsocketTxBlk(pin, IP, port):
+    """
+
+    Call:   TCPsocketTxBlk(pin, IP, port)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       IP : IP Addr
+       port :  Port
+
+    Returns
+    -------
+       blk: RCPblk
+
+    """
+
+    blk = RCPblk('TCPsocketTx', pin, [], [0,0], 1, [], [port, 0], IP)
+    return blk

--- a/resources/blocks/rcpBlk/help/TCPsocketTxBlk.hlp
+++ b/resources/blocks/rcpBlk/help/TCPsocketTxBlk.hlp
@@ -1,0 +1,5 @@
+This block implements a TCP sender
+
+Parameters
+IP address of the receiver
+Port

--- a/resources/blocks/rcpBlk/help/discretePIDBlk.hlp
+++ b/resources/blocks/rcpBlk/help/discretePIDBlk.hlp
@@ -1,0 +1,8 @@
+Discrete PID controller
+
+Parameters
+Proportional gain
+Integral gain
+Discrete gain
+Min value: minimal output value
+Max value: maximal output value

--- a/resources/blocks/rcpBlk/linear/discretePIDBlk.py
+++ b/resources/blocks/rcpBlk/linear/discretePIDBlk.py
@@ -1,0 +1,23 @@
+from supsisim.RCPblk import RCPblk
+from scipy import size
+
+def discretePIDBlk(pin, pout, Kp, Ki, Kd, min_val, max_val):
+    """
+
+    Call:   nuttx_PWMBlk(pin, port, umin, umax)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       port : Port
+       umin : Umin [V]
+       umax : Umax [V]
+
+    Returns
+    -------
+       blk: RCPblk
+
+    """
+
+    blk = RCPblk('discretePID', pin, pout, [0,0], 1, [Kp, Ki, Kd, min_val, max_val, 0, 0], [])
+    return blk


### PR DESCRIPTION
This PR adds discrete PID block with implemented anti-windup and TCP Socket TX block with added support for NuttX targets. The TCP communication was tested with tcpRTScope.py application (variation of serRTScope.py in BlockEditor/), which can be found here (https://github.com/michallenc/pysimCoder/blob/dc_motor/BlockEditor/tcpRTScope.py). It is currently just a working version without proper QT window (it still has options from serial application), but the data receive works.