### PR TITLE
Update nuttx_PWM.c file to support multiple PWM blocks

### DIFF
--- a/CodeGen/nuttx/.gitignore
+++ b/CodeGen/nuttx/.gitignore
@@ -1,3 +1,3 @@
-nuttx-export
+nuttx-export*
 lib/*.a
 devices/*.o


### PR DESCRIPTION
This PR removes global declaration of pwm_info_s structure and moves it locally to functions init() and inout() to support multiple PWM blocks. It is necessary to run for loop from 0 to CONFIG_PWM_NCHANNELS and set all channels to 0 also in inout() function, otherwise there will be hard faults. Also adds some comments as the code was getting a little bit harder to read.

I also experimented a little bit with completely removing pwm_info_s structure from init() function and then removing PWMIOC_SETCHARACTERISTICS ioctl command from that function too so init() would only open the device and then execute PWMIOC_START start command. It seemed to be working fine but then I found out that PWMIOC_SETCHARACTERISTICS should be sent before PWMIOC_START according to this https://github.com/apache/incubator-nuttx/blob/master/drivers/timers/pwm.c#L497. But maybe it is worth to take a closer look at this in the future.