### PR TITLE
Math: add blocks for Park and Clarke transformations

### DIFF
--- a/CodeGen/Common/common_dev/clarke_trans.c
+++ b/CodeGen/Common/common_dev/clarke_trans.c
@@ -1,0 +1,107 @@
+/*
+COPYRIGHT (C) 2021  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <math.h>
+
+/****************************************************************************
+ * Name: forward_clarke
+ *
+ * Description:
+ *   Computes forward Clarke transformation. It is possible to use both
+ *   calculations for 2 and 3 inputs.
+ *
+ ****************************************************************************/
+
+void forward_clarke(int Flag, python_block *block)
+{
+  double *alpha = block->y[0];
+  double *beta = block->y[1];
+  double *cur1 = block->u[0];
+  double *cur2 = block->u[1];
+
+  double cur_alp;
+  double cur_bet;
+
+  switch(Flag)
+    {
+      case CG_OUT:
+      case CG_INIT:
+      case CG_END:
+        if (block->nin == 2)
+          {
+            /* Only two inputs are used */
+
+            cur_alp = cur1[0];
+            cur_bet = 2 * cur2[0] + cur1[0];
+          }
+        else
+          {
+            /* We read data from all 3 inputs */
+
+            double *cur3 = block->u[2];
+
+            cur_alp = (-cur2[0] - cur3[0] + 2 * cur1[0]) / 3;
+            cur_bet = (cur2[0] - cur3[0]) + 2 * cur2[0] + cur1[0] - (2 * cur3[0] + cur1[0]);
+
+            /* Make an average */
+
+            cur_bet = cur_bet / 3;
+          }
+
+        cur_bet = cur_bet / sqrt(3);
+
+        /* Save alpha and beta to outputs */
+
+        alpha[0] = cur_alp;
+        beta[0] = cur_bet;
+        break;
+      default:
+        break;
+    }
+}
+
+/****************************************************************************
+ * Name: inverse_clarke
+ *
+ * Description:
+ *   Computes inverse Clarke transformation.
+ *
+ ****************************************************************************/
+
+void inverse_clarke(int Flag, python_block *block)
+{
+  double *cur1 = block->y[0];
+  double *cur2 = block->y[1];
+  double *cur3 = block->y[2];
+  double *alpha = block->u[0];
+  double *beta = block->u[1];
+
+  switch(Flag)
+    {
+      case CG_OUT:
+      case CG_INIT:
+      case CG_END:
+        cur1[0] = alpha[0];
+        cur2[0] = -0.5f * alpha[0] + 0.5f * sqrt(3) * beta[0]; 
+        cur3[0] = -0.5f * alpha[0] - 0.5f * sqrt(3) * beta[0]; 
+        break;
+      default:
+        break;
+    }
+}

--- a/CodeGen/Common/common_dev/park_trans.c
+++ b/CodeGen/Common/common_dev/park_trans.c
@@ -1,0 +1,78 @@
+/*
+COPYRIGHT (C) 2021  Roberto Bucher (roberto.bucher@supsi.ch)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <math.h>
+
+/****************************************************************************
+ * Name: forward_park
+ *
+ * Description:
+ *   Computes forward Park transformation.
+ *
+ ****************************************************************************/
+
+void forward_park(int Flag, python_block *block)
+{
+  double *d = block->y[0];
+  double *q = block->y[1];
+  double *alpha = block->u[0];
+  double *beta = block->u[1];
+  double *rot_angle = block->u[2];
+
+  switch(Flag)
+    {
+      case CG_OUT:
+      case CG_INIT:
+      case CG_END:
+        d[0] = alpha[0] * cos(rot_angle[0]) + beta[0] * sin(rot_angle[0]);
+        q[0] = -alpha[0] * sin(rot_angle[0]) + beta[0] * cos(rot_angle[0]);
+        break;
+      default:
+        break;
+    }
+}
+
+/****************************************************************************
+ * Name: inverse_park
+ *
+ * Description:
+ *   Computes inverse Park transformation.
+ *
+ ****************************************************************************/
+
+void inverse_park(int Flag, python_block *block)
+{
+  double *alpha = block->y[0];
+  double *beta= block->y[1];
+  double *d = block->u[0];
+  double *q = block->u[1];
+  double *rot_angle = block->u[2];
+
+  switch(Flag)
+    {
+      case CG_OUT:
+      case CG_INIT:
+      case CG_END:
+        alpha[0] = d[0] * cos(rot_angle[0]) - q[0] * sin(rot_angle[0]);
+        beta[0] = d[0] * sin(rot_angle[0]) + q[0] * cos(rot_angle[0]);
+        break;
+      default:
+        break;
+    }
+}

--- a/resources/blocks/Icons/FORWARD_CLARKE.svg
+++ b/resources/blocks/Icons/FORWARD_CLARKE.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="FORWARD_CLARKE.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="8.0000008"
+     inkscape:cy="23.593221"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.277061"
+     y="19.949152"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       x="32.277061"
+       y="19.949152"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32">FORWARD</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.209267"
+     y="33.406776"
+     id="text3361-3"><tspan
+       sodipodi:role="line"
+       x="32.209267"
+       y="33.406776"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32-6">CLARKE</tspan></text>
+</svg>

--- a/resources/blocks/Icons/FORWARD_PARK.svg
+++ b/resources/blocks/Icons/FORWARD_PARK.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="FORWARD_PARK.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="8.0000008"
+     inkscape:cy="23.593221"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.277061"
+     y="19.949152"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       x="32.277061"
+       y="19.949152"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32">FORWARD</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.209267"
+     y="33.406776"
+     id="text3361-3"><tspan
+       sodipodi:role="line"
+       x="32.209267"
+       y="33.406776"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32-6">PARK</tspan></text>
+</svg>

--- a/resources/blocks/Icons/INVERSE_CLARKE.svg
+++ b/resources/blocks/Icons/INVERSE_CLARKE.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="INVERSE_CLARKE.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="8.0000008"
+     inkscape:cy="23.593221"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.277061"
+     y="19.949152"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       x="32.277061"
+       y="19.949152"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32">INVERSE</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.209267"
+     y="33.406776"
+     id="text3361-3"><tspan
+       sodipodi:role="line"
+       x="32.209267"
+       y="33.406776"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32-6">CLARKE</tspan></text>
+</svg>

--- a/resources/blocks/Icons/INVERSE_PARK.svg
+++ b/resources/blocks/Icons/INVERSE_PARK.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="INVERSE_PARK.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="8.0000008"
+     inkscape:cy="23.593221"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.277061"
+     y="19.949152"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       x="32.277061"
+       y="19.949152"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32">INVERSE</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.209267"
+     y="33.406776"
+     id="text3361-3"><tspan
+       sodipodi:role="line"
+       x="32.209267"
+       y="33.406776"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32-6">PARK</tspan></text>
+</svg>

--- a/resources/blocks/blocks/Math/clarke_forward.xblk
+++ b/resources/blocks/blocks/Math/clarke_forward.xblk
@@ -1,0 +1,1 @@
+{"lib": "math", "name": "Forward Clarke", "ip": 3, "op": 2, "stin": 1, "stout": 0, "icon": "FORWARD_CLARKE", "params": "clarke_forwardBlk", "help": "This block performs forward Clarke transformation.\nBlock can have either 2 or 3 inputs.\n"}

--- a/resources/blocks/blocks/Math/clarke_inverse.xblk
+++ b/resources/blocks/blocks/Math/clarke_inverse.xblk
@@ -1,0 +1,1 @@
+{"lib": "math", "name": "Inverse Clarke", "ip": 2, "op": 3, "stin": 0, "stout": 0, "icon": "INVERSE_CLARKE", "params": "clarke_inverseBlk", "help": "This block performs inverse Clarke transformation.\n"}

--- a/resources/blocks/blocks/Math/park_forward.xblk
+++ b/resources/blocks/blocks/Math/park_forward.xblk
@@ -1,0 +1,1 @@
+{"lib": "math", "name": "Forward Park", "ip": 3, "op": 2, "stin": 0, "stout": 0, "icon": "FORWARD_PARK", "params": "park_forwardBlk", "help": "This block performs forward Park transformation.\nFirst two inputs are for orthogonal stationary reference frame quantities, the third one is for the rotation angle.\n"}

--- a/resources/blocks/blocks/Math/park_inverse.xblk
+++ b/resources/blocks/blocks/Math/park_inverse.xblk
@@ -1,0 +1,1 @@
+{"lib": "math", "name": "Inverse Park", "ip": 3, "op": 2, "stin": 0, "stout": 0, "icon": "INVERSE_PARK", "params": "park_inverseBlk", "help": "This block performs inverse Park transformation.\nFirst two inputs are for rotating reference frame quantities, the third one is for the rotation angle.\n"}

--- a/resources/blocks/rcpBlk/Math/clarke_forwardBlk.py
+++ b/resources/blocks/rcpBlk/Math/clarke_forwardBlk.py
@@ -1,0 +1,25 @@
+from supsisim.RCPblk import RCPblk
+from scipy import size
+
+def clarke_forwardBlk(pin, pout):
+    """
+
+    Call:   clarke_forwardBlk(pin, pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+        blk  : RCPblk
+
+    """
+
+    if (size(pin) != 3 and size(pin) != 2):
+        raise ValueError("Forward Clarke transformation has to have 2 or 3 inputs, current number of inputs is (%i)" % (size(pin)))
+
+    blk = RCPblk('forward_clarke', pin, pout, [0,0], 1, [], [])
+    return blk
+

--- a/resources/blocks/rcpBlk/Math/clarke_inverseBlk.py
+++ b/resources/blocks/rcpBlk/Math/clarke_inverseBlk.py
@@ -1,0 +1,22 @@
+from supsisim.RCPblk import RCPblk
+from scipy import size
+
+def clarke_inverseBlk(pin, pout):
+    """
+
+    Call:   clarke_inverseBlk(pin, pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+        blk  : RCPblk
+
+    """
+
+    blk = RCPblk('inverse_clarke', pin, pout, [0,0], 1, [], [])
+    return blk
+

--- a/resources/blocks/rcpBlk/Math/park_forwardBlk.py
+++ b/resources/blocks/rcpBlk/Math/park_forwardBlk.py
@@ -1,0 +1,22 @@
+from supsisim.RCPblk import RCPblk
+from scipy import size
+
+def park_forwardBlk(pin, pout):
+    """
+
+    Call:   park_forwardBlk(pin, pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+        blk  : RCPblk
+
+    """
+
+    blk = RCPblk('forward_park', pin, pout, [0,0], 1, [], [])
+    return blk
+

--- a/resources/blocks/rcpBlk/Math/park_inverseBlk.py
+++ b/resources/blocks/rcpBlk/Math/park_inverseBlk.py
@@ -1,0 +1,22 @@
+from supsisim.RCPblk import RCPblk
+from scipy import size
+
+def park_inverseBlk(pin, pout):
+    """
+
+    Call:   park_inverseBlk(pin, pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+        blk  : RCPblk
+
+    """
+
+    blk = RCPblk('inverse_park', pin, pout, [0,0], 1, [], [])
+    return blk
+


### PR DESCRIPTION
This commit adds new block for forward and inverse Clarke and Park transformations. Forward Clarke transformation can be used either with 2 or 3 inputs. The output values are averaging when using 3 inputs so the noise on channels has less effect on the control application.