### PR TITLE
add pysim-run.sh skript to run pysimCoder from source code without installation

### DIFF
--- a/pysim-run.sh
+++ b/pysim-run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+export PYSUPSICTRL="$( cd "$(dirname "$0")" ; pwd )"
+
+if [ -n "$PYTHONPATH" ] ; then
+  PYTHONPATH=":$PYTHONPATH"
+fi
+export PYTHONPATH="$PYSUPSICTRL/resources/blocks/rcpBlk:$PYSUPSICTRL/toolbox$PYTHONPATH"
+
+if true ; then
+  #export PYTHONPATH="$PYSUPSICTRL/toolbox/supsisim/src:$PYSUPSICTRL/toolbox/supsictrl/src:$PYTHONPATH"
+  PYSUPSICTRL_LINKS="$HOME/Documents/PYTHON/toolbox"
+  mkdir -p "$PYSUPSICTRL_LINKS"
+  rm -f "$PYSUPSICTRL_LINKS/supsisim"
+  ln -s "$PYSUPSICTRL/toolbox/supsisim/src" "$PYSUPSICTRL_LINKS/supsisim"
+  rm -f "$PYSUPSICTRL_LINKS/supsictrl"
+  ln -s "$PYSUPSICTRL/toolbox/supsictrl/src" "$PYSUPSICTRL_LINKS/supsictrl"
+  export PYTHONPATH="$PYSUPSICTRL_LINKS:$PYTHONPATH"
+fi
+
+/usr/bin/python3 "$PYSUPSICTRL/BlockEditor/pysimCoder.py" "$@"


### PR DESCRIPTION
Adds skript pysim-run.sh that allows to run pysimCoder without the application being installed on the system. PysimCoder can then
be run from its root directory by executing ./pysim-run.sh (on Linux systems).