### PR TITLE
NuttX: update Serial Out block to select device port from parameters

### DIFF
--- a/CodeGen/nuttx/devices/serialOut.c
+++ b/CodeGen/nuttx/devices/serialOut.c
@@ -26,7 +26,7 @@ static void init(python_block *block)
   int * intPar  = block->intPar;
   int fd;
 
-  fd =  open("/dev/ttyS0", O_WRONLY);
+  fd =  open(block->str, O_WRONLY);
   intPar[0] = fd;
 }
 

--- a/resources/blocks/blocks/NuttX/nuttxSerialOut.xblk
+++ b/resources/blocks/blocks/NuttX/nuttxSerialOut.xblk
@@ -1,1 +1,1 @@
-{"lib": "NuttX", "name": "serialOut", "ip": 1, "op": 0, "stin": 1, "stout": 0, "icon": "SERIAL", "params": "nuttxSerialOutBlk|Decimation:1", "help": " No help available for this block"}
+{"lib": "NuttX", "name": "serialOut", "ip": 1, "op": 0, "stin": 1, "stout": 0, "icon": "SERIAL", "params": "nuttxSerialOutBlk|Port:'/dev/ttyS0'|Decimation:1", "help": "Parameters\nPort: device name\n\n"}

--- a/resources/blocks/rcpBlk/NuttX/nuttxSerialOutBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttxSerialOutBlk.py
@@ -2,7 +2,7 @@
 from supsisim.RCPblk import RCPblk
 from scipy import size
 
-def nuttxSerialOutBlk(pin, decim):
+def nuttxSerialOutBlk(pin, port, decim):
     """
 
     Call:   brikiSerialOut(pin, decim)
@@ -20,5 +20,5 @@ def nuttxSerialOutBlk(pin, decim):
 
     decim = int(decim)
     
-    blk = RCPblk('serialOut', pin, [], [0,0], 1, [], [decim, 0])
+    blk = RCPblk('serialOut', pin, [], [0,0], 1, [], [decim, 0], port)
     return blk


### PR DESCRIPTION
This change allows the user to select device port (ttyS0 etc.) from block parameters instead of having predefined one port in the code.