### PR TITLE
RTScope: add option to select baud rate from the scope widget

### DIFF
--- a/BlockEditor/RTScope.py
+++ b/BlockEditor/RTScope.py
@@ -48,8 +48,10 @@ class ser_rcvServer(threading.Thread):
     def run(self):
         portN =  self.mainw.serCbBox.currentIndex()
         portName = self.mainw.serCbBox.itemText(portN)
+        baudN = self.mainw.serBaudRate.currentIndex()
+        baudRate = self.mainw.serBaudRate.itemText(baudN)
 
-        self.port = ser.Serial(portName, 1200000)
+        self.port = ser.Serial(portName, baudRate)
         T = 0.0
         L = 8*self.N
         
@@ -80,10 +82,12 @@ class ser_rcvServer4bytes(threading.Thread):
         self.st = struct.Struct(self.N*'d')
        
     def run(self):
-        portN =  self.mainw.serCbBox.currentIndex()
-        portName = self.mainw.serCbBox.itemText(portN)
+        portN =  self.mainw.ser4CbBox.currentIndex()
+        portName = self.mainw.ser4CbBox.itemText(portN)
+        baudN = self.mainw.ser4BaudRate.currentIndex()
+        baudRate = self.mainw.ser4BaudRate.itemText(baudN)
 
-        self.port = ser.Serial(portName, 1200000)
+        self.port = ser.Serial(portName, baudRate)
         T = 0.0
         L = 4*self.N
         

--- a/BlockEditor/pyplt.ui
+++ b/BlockEditor/pyplt.ui
@@ -272,6 +272,68 @@
        <string>/dev/ttyACM2</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>/dev/ttyUSB0</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QLabel" name="label">
+     <property name="geometry">
+      <rect>
+       <x>40</x>
+       <y>70</y>
+       <width>111</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Baud Rate</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="serBaudRate">
+     <property name="geometry">
+      <rect>
+       <x>170</x>
+       <y>65</y>
+       <width>161</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="editable">
+      <bool>true</bool>
+     </property>
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>9600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>57600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>115200</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>576000</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1200000</string>
+      </property>
+     </item>
     </widget>
     <widget class="QPushButton" name="pbStart_ser">
      <property name="geometry">
@@ -321,6 +383,11 @@
        <string>/dev/ttyACM2</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>/dev/ttyUSB0</string>
+      </property>
+     </item>
     </widget>
     <widget class="QLabel" name="label_7">
      <property name="geometry">
@@ -337,6 +404,63 @@
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
+    </widget>
+    <widget class="QLabel" name="label">
+     <property name="geometry">
+      <rect>
+       <x>40</x>
+       <y>70</y>
+       <width>111</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Baud Rate</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="ser4BaudRate">
+     <property name="geometry">
+      <rect>
+       <x>170</x>
+       <y>65</y>
+       <width>161</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="editable">
+      <bool>true</bool>
+     </property>
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>9600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>57600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>115200</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>576000</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1200000</string>
+      </property>
+     </item>
     </widget>
     <widget class="QPushButton" name="pbStart_ser4">
      <property name="geometry">


### PR DESCRIPTION
Small update for RTScope tool to allow selection of baud rate from the graphical widget instead of rewriting the code. Tested with sending data over UART from Teensy 4.1