### PR TITLE
Common: fix implementation of anti-windup in discrete PID block

### DIFF
--- a/CodeGen/Common/common_dev/discretePID.c
+++ b/CodeGen/Common/common_dev/discretePID.c
@@ -82,7 +82,7 @@ static void inout(python_block *block)
     }
   else if (action < min_val)
     {
-      integral_sum = integral_sum - (-action + min_val);
+      integral_sum = integral_sum - (action + min_val);
       action = min_val;
     }
 


### PR DESCRIPTION
This fixes mistake in anti-windup computation in discrete PID block presented in PR #16. The wrong sign was causing instability in some cases.