### PR TITLE
CodeGen: added .gitignore files to ignore *.o and *.a files

### DIFF
--- a/CodeGen/LinuxRT/.gitignore
+++ b/CodeGen/LinuxRT/.gitignore
@@ -1,0 +1,2 @@
+lib/*.a
+devices/*.o

--- a/CodeGen/Raspberry_PI/.gitignore
+++ b/CodeGen/Raspberry_PI/.gitignore
@@ -1,0 +1,2 @@
+lib/*.a
+devices/*.o

--- a/CodeGen/SAMD21/.gitignore
+++ b/CodeGen/SAMD21/.gitignore
@@ -1,0 +1,2 @@
+lib/*.a
+devices/*.o

--- a/CodeGen/STM32H7/.gitignore
+++ b/CodeGen/STM32H7/.gitignore
@@ -1,0 +1,2 @@
+lib/*.a
+devices/*.o

--- a/CodeGen/linux_mz_apo/.gitignore
+++ b/CodeGen/linux_mz_apo/.gitignore
@@ -1,0 +1,2 @@
+lib/*.a
+devices/*.o


### PR DESCRIPTION
Added few gitignore files to ignore *.o and *.a files after compilation.