### PR TITLE
CodeGen/nuttx: more makefiles tuning to support RISC-V (ESP32C3).

### DIFF
--- a/CodeGen/nuttx/devices/Makefile
+++ b/CodeGen/nuttx/devices/Makefile
@@ -78,8 +78,12 @@ ELF_MODULE_LIBS = --start-group $(EXTRA_LIBS) --end-group
 
 LDFLAGS += -L $(NUTTX_EXPORT)/libs
 
+ifneq ($(shell $(CC) --target-help | grep -e '-mlong-calls\b'),)
+TARGET_ARCH_LONG_CALLS = -mlong-calls
+endif
+
 TARGET_ARCH_FLAGS ?= $(ARCHCFLAGS) $(ARCHCPUFLAGS) \
-	-mlong-calls -fno-common -DWITHOUT_MLOCK
+	$(TARGET_ARCH_LONG_CALLS) -fno-common -DWITHOUT_MLOCK
 
 DEFAULT_OPT_OPTS ?= $(ARCHOPTIMIZATION)
 

--- a/CodeGen/templates/nuttx.tmf
+++ b/CodeGen/templates/nuttx.tmf
@@ -45,8 +45,12 @@ ELF_MODULE_LIBS = $(LDSTARTGROUP) $(EXTRA_LIBS) $(LDENDGROUP)
 
 LDFLAGS += -L $(NUTTX_EXPORT)/libs
 
+ifneq ($(shell $(CC) --target-help | grep -e '-mlong-calls\b'),)
+TARGET_ARCH_LONG_CALLS = -mlong-calls
+endif
+
 TARGET_ARCH_FLAGS ?= $(ARCHCFLAGS) $(ARCHCPUFLAGS) \
-	-mlong-calls -fno-common -DWITHOUT_MLOCK
+	$(TARGET_ARCH_LONG_CALLS) -fno-common -DWITHOUT_MLOCK
 
 DEFAULT_OPT_OPTS ?= $(ARCHOPTIMIZATION)
 
@@ -54,9 +58,9 @@ ifndef OPT_OPTS
 OPT_OPTS = $(DEFAULT_OPT_OPTS)
 endif
 
-LD_SCRIPT = $(NUTTX_EXPORT)/scripts/$(LDNAME)
+LD_SCRIPTS = $(LDNAME:%=$(NUTTX_EXPORT)/scripts/%)
 
-LDFLAGS += -T $(LD_SCRIPT)
+LDFLAGS_LD_SCRIPTS += $(LD_SCRIPTS:%=-T %)
 
 LDFLAGS  += --entry=__start
 
@@ -108,13 +112,14 @@ $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	[ ! -e  $(ELF_FILE_LDSCRIPT) ] || \
 	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) -o $@ \
 	  -r -e main -T $(ELF_FILE_LDSCRIPT) \
-	  $(GCC_LD_OPTION)-Map $(GCC_LD_OPTION)$(1).elf.map \
+	  $(GCC_LD_OPTION)-Map $(GCC_LD_OPTION)$(notdir $@).map \
 	  $(OBJSSTAN) $(LIB) $(LIBS) $(ELF_MODULE_LIBS)
 	@echo "### Created ELF loadable file: $(MODEL).elf"
 
 ../$(MODEL): $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB)
-	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) \
-	  -o $@  $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB) $(SYSTEM_LIBS)
+	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) $(LDFLAGS_LD_SCRIPTS) \
+	  -o $@ $(HEAD_OBJ:%=$(NUTTX_EXPORT)/startup/%) \
+	  $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB) $(SYSTEM_LIBS)
 	@echo "### Created executable: $(MODEL)"
 
 ../$(MODEL).hex : ../$(MODEL)

--- a/CodeGen/templates/nuttx_sem.tmf
+++ b/CodeGen/templates/nuttx_sem.tmf
@@ -45,8 +45,12 @@ ELF_MODULE_LIBS = $(LDSTARTGROUP) $(EXTRA_LIBS) $(LDENDGROUP)
 
 LDFLAGS += -L $(NUTTX_EXPORT)/libs
 
+ifneq ($(shell $(CC) --target-help | grep -e '-mlong-calls\b'),)
+TARGET_ARCH_LONG_CALLS = -mlong-calls
+endif
+
 TARGET_ARCH_FLAGS ?= $(ARCHCFLAGS) $(ARCHCPUFLAGS) \
-	-mlong-calls -fno-common -DWITHOUT_MLOCK
+	$(TARGET_ARCH_LONG_CALLS) -fno-common -DWITHOUT_MLOCK
 
 DEFAULT_OPT_OPTS ?= $(ARCHOPTIMIZATION)
 
@@ -54,9 +58,9 @@ ifndef OPT_OPTS
 OPT_OPTS = $(DEFAULT_OPT_OPTS)
 endif
 
-LD_SCRIPT = $(NUTTX_EXPORT)/scripts/$(LDNAME)
+LD_SCRIPTS = $(LDNAME:%=$(NUTTX_EXPORT)/scripts/%)
 
-LDFLAGS += -T $(LD_SCRIPT)
+LDFLAGS_LD_SCRIPTS += $(LD_SCRIPTS:%=-T %)
 
 LDFLAGS  += --entry=__start
 
@@ -108,13 +112,14 @@ $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	[ ! -e  $(ELF_FILE_LDSCRIPT) ] || \
 	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) -o $@ \
 	  -r -e main -T $(ELF_FILE_LDSCRIPT) \
-	  $(GCC_LD_OPTION)-Map $(GCC_LD_OPTION)$(1).elf.map \
+	  $(GCC_LD_OPTION)-Map $(GCC_LD_OPTION)$(notdir $@).map \
 	  $(OBJSSTAN) $(LIB) $(LIBS) $(ELF_MODULE_LIBS)
 	@echo "### Created ELF loadable file: $(MODEL).elf"
 
 ../$(MODEL): $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB)
-	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) \
-	  -o $@  $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB) $(SYSTEM_LIBS)
+	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) $(LDFLAGS_LD_SCRIPTS) \
+	  -o $@ $(HEAD_OBJ:%=$(NUTTX_EXPORT)/startup/%) \
+	  $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB) $(SYSTEM_LIBS)
 	@echo "### Created executable: $(MODEL)"
 
 ../$(MODEL).hex : ../$(MODEL)


### PR DESCRIPTION
The pysimCoder models generation for NuttX target has been
tested only for ARM based targets till now.

RISC-V does not support -mlong-calls option which is used
on ARM targets to generate code which can be relocated
to call NuttX system exported symbols when model is build
as standalone application. Check for option availability
before its use.

Then ESP32C3 environment exported by NuttX specifies
multiple linker scripts which should be used. Be prepare
for more than one of them.

The last, nuttx-export/startup/esp32c3_head.o file
has to be included into whole NuttX image linking
command. It should be specified in Make.defs HEAD_OBJ.
It is missing there for now and Make.defs has to be tuned
manually.

Signed-off-by: Pavel Pisa <pisa@cmp.felk.cvut.cz>