### PR TITLE
Blocks for control of 3-Phase DC motor over SPI

### DIFF
--- a/CodeGen/Raspberry_PI/devices/P3M_spi.c
+++ b/CodeGen/Raspberry_PI/devices/P3M_spi.c
@@ -1,0 +1,188 @@
+/*
+COPYRIGHT (C) 2022  Dion Beqiri (beqirdio@fel.cvut.cz)
+
+Description: C-code for driving 3-Phase Motor on Raspberry Pi
+              using pysimCoder
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* supporting files for Raspberry Pi */
+#include "rpi_gpio.h"
+#include "rpi_spimc.h"
+#include "rpi_gpclk.h"
+
+/* parameters index definition */
+
+const unsigned char pxmc_lpc_bdc_hal_pos_table[8] =
+{
+  [0] = 0xff,
+  [7] = 0xff,
+  [1] = 0, /*0*/
+  [5] = 1, /*1*/
+  [4] = 2, /*2*/
+  [6] = 3, /*3*/
+  [2] = 4, /*4*/
+  [3] = 5, /*5*/
+};
+
+/*  INITIALIZATION FUNCTION  */
+static void init(python_block *block)
+{
+  spimc_state_t *spimcst;
+
+  block->ptrPar = NULL;
+
+  if (rpi_peripheral_registers_map() <= 0) {
+      fprintf(stderr, "rpi_peripheral_registers_map failed");
+      return;
+  }
+
+  spimcst = malloc(sizeof(*spimcst));
+  if (spimcst == NULL) {
+      fprintf(stderr, "malloc spimcst failed");
+      return;
+  }
+  memset(spimcst, sizeof(*spimcst), 0);
+
+  spimcst->spi_dev = "/dev/spidev0.1";
+
+  if (spimc_init(spimcst) < 0) {
+      fprintf(stderr, "spimc_init spimcst failed");
+      return;
+  }
+
+  block->ptrPar = (void*) spimcst;
+
+  if (rpi_gpclk_setup(0, RPI_GPCLK_PLLD_500_MHZ, 10, 0) < 0) {
+      fprintf(stderr, "rpi_gpclk_setup failed\n");
+      return;
+  }
+
+  if (rpi_gpio_alt_fnc(4 /*gpio*/, 0/*alt_fnc*/) < 0) {
+      fprintf(stderr, "rpi_gpio_alt_fnc failed\n");
+      return;
+  }
+
+  spimc_transfer(spimcst);
+
+  // Initialize conditions
+
+  spimcst->curadc_offs[0] = 0; /*2072*/
+  spimcst->curadc_offs[1] = 0; /*2077*/
+  spimcst->curadc_offs[2] = 0; /*2051*/
+
+  spimcst->pos_offset = -spimcst->act_pos;
+
+}
+
+/*  INPUT/OUTPUT  FUNCTION  */
+static void inout(python_block *block)
+{
+  double *pwm_val[3] = {block->u[0], block->u[1], block->u[2]};
+  double *pwm_en[3] = {block->u[3], block->u[4], block->u[5]};
+
+  spimc_state_t *spimcst = (spimc_state_t *)block->ptrPar;
+  int i;
+  double pwm;
+
+  spimcst->curadc_sqn_last = spimcst->curadc_sqn;
+
+  for (i = 0; i < SPIMC_CHAN_COUNT; i++)
+      spimcst->curadc_cumsum_last[i] = spimcst->curadc_cumsum[i];
+
+  for (i = 0; i < SPIMC_CHAN_COUNT; i++) {
+      if (pwm_en[i][0]) {
+          pwm = pwm_val[i][0] * 2048;
+          if (pwm > 2047)
+              pwm = 2047;
+          if (pwm < 0)
+              pwm = 0;
+          spimcst->pwm[i] = (uint32_t)pwm | SPIMC_PWM_ENABLE;
+      } else {
+          spimcst->pwm[i] = 0 | SPIMC_PWM_SHUTDOWN;
+      }
+  }
+
+  spimc_transfer(spimcst);
+
+  /* Update outputs */
+  double *cur_adc[3] = {block->y[0], block->y[1], block->y[2]};
+  double *irc_pos = block->y[3];
+  double *irc_idx = block->y[4];
+  double *irc_idx_occ = block->y[5];
+  double *hal_sec = block->y[6];
+
+  uint32_t curadc_sqn_diff;
+  uint32_t curadc_val_diff;
+  int diff_to_last_fl = 0;
+
+  curadc_sqn_diff = spimcst->curadc_sqn;
+  if (diff_to_last_fl) {
+    curadc_sqn_diff -= spimcst->curadc_sqn_last;
+    curadc_sqn_diff &= 0x1ff;
+  }
+
+  if ((curadc_sqn_diff > 1) && (curadc_sqn_diff <= 450)) {
+      for (i = 0; i < SPIMC_CHAN_COUNT; i++) {
+          curadc_val_diff = spimcst->curadc_cumsum[i];
+          if (diff_to_last_fl) {
+            curadc_val_diff -= spimcst->curadc_cumsum_last[i];
+            curadc_val_diff &= 0xffffff;
+          }
+          cur_adc[i][0] = (double)curadc_val_diff / (double)curadc_sqn_diff -
+                          (double)spimcst->curadc_offs[i];
+      }
+  }
+
+  irc_pos[0] = (double)(spimcst->act_pos + spimcst->pos_offset);
+  irc_idx[0] = (double)(spimcst->index_pos + spimcst->pos_offset);
+  irc_idx_occ[0] = (double)spimcst->index_occur;
+  hal_sec[0] = (double)pxmc_lpc_bdc_hal_pos_table[spimcst->hal_sensors];
+
+
+}
+
+/*  TERMINATION FUNCTION  */
+static void end(python_block *block)
+{
+  spimc_state_t *spimcst = (spimc_state_t *)block->ptrPar;
+
+  if (spimcst != NULL) {
+      block->ptrPar = NULL;
+      free(spimcst);
+      rpi_gpio_direction_output(4, 0);
+  }
+
+}
+
+void P3M_spi(int flag, python_block *block)
+{
+  if (flag==CG_OUT){          /* input / output */
+    inout(block);
+  }
+  else if (flag==CG_END){     /* termination */
+    end(block);
+  }
+  else if (flag ==CG_INIT){    /* initialisation */
+    init(block);
+  }
+}

--- a/CodeGen/Raspberry_PI/devices/rpi_gpclk.c
+++ b/CodeGen/Raspberry_PI/devices/rpi_gpclk.c
@@ -1,0 +1,98 @@
+/**
+ * (C) 2015 by Martin Prudek prudemar@fel.cvut.cz
+ * (C) 2015 by Pavel Pisa pisa@cmp.felk.cvut.cz
+ *
+ * Configuration of the General Purpose Clocks outputs
+ * Inspired by wiringPi written by Gordon Henderson.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <poll.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+
+#include "rpi_gpio.h"
+#include "rpi_gpclk.h"
+
+#define CLK_GPx_CTL(chan) \
+  (rpi_registers_mapping.clk_base[28 + 2 * (chan)])
+
+#define CLK_GPx_DIV(chan) \
+  (rpi_registers_mapping.clk_base[29 + 2 * (chan)])
+
+#define CLK_CTL_SRC_OSC  1  /* 19.2 MHz */
+#define CLK_CTL_SRC_PLLC 5  /* 1000 MHz */
+#define CLK_CTL_SRC_PLLD 6  /*  500 MHz */
+#define CLK_CTL_SRC_HDMI 7  /*  216 MHz */
+
+#define CLK_PASSWD  (0x5A<<24)
+#define CLK_CTL_MASH(x)((x)<<9)
+#define CLK_CTL_BUSY    (1 <<7)
+#define CLK_CTL_KILL    (1 <<5)
+#define CLK_CTL_ENAB    (1 <<4)
+#define CLK_CTL_SRC(x) ((x)<<0)
+
+#define CLK_DIV_DIVI(x) ((x)<<12)
+#define CLK_DIV_DIVF(x) ((x)<< 0)
+
+uint32_t rpi_gpclk_src_to_reg[] = {
+    [RPI_GPCLK_PLLD_500_MHZ] = CLK_CTL_SRC_PLLD,
+    [RPI_GPCLK_OSC_19_MHZ_2] = CLK_CTL_SRC_OSC,
+    [RPI_GPCLK_HDMI_216_MHZ] = CLK_CTL_SRC_HDMI,
+    [RPI_GPCLK_PLLC_1000_MHZ] = CLK_CTL_SRC_PLLD,
+};
+
+int rpi_gpclk_setup(int chan, int source, int div_int, int div_frac)
+{
+    int MASH = 0;
+    uint32_t clksrc;
+
+    if (!rpi_registers_mapping.mapping_initialized)
+        return -1;
+
+    if ((source < 0) || (source > sizeof(rpi_gpclk_src_to_reg) /
+         sizeof(*rpi_gpclk_src_to_reg) ))
+        return -2;
+
+    if ((div_int  < 2) || (div_int   > 4095))
+        return -3;
+
+    if ((div_frac < 0) || (div_frac  > 4095))
+        return -4;
+
+    if ((MASH   < 0) || (MASH   > 3))
+        return -5;
+
+    clksrc = rpi_gpclk_src_to_reg[source];
+
+    CLK_GPx_CTL(chan) = CLK_PASSWD | CLK_CTL_KILL;
+
+    while (CLK_GPx_CTL(chan) & CLK_CTL_BUSY){
+        usleep(10);
+    }
+
+    CLK_GPx_DIV(chan) = (CLK_PASSWD | CLK_DIV_DIVI(div_int) | CLK_DIV_DIVF(div_frac));
+
+    usleep(10);
+
+    CLK_GPx_CTL(chan) = (CLK_PASSWD | CLK_CTL_MASH(MASH) | CLK_CTL_SRC(clksrc));
+
+    usleep(10);
+
+    CLK_GPx_CTL(chan) |= (CLK_PASSWD | CLK_CTL_ENAB);
+
+    return 0;
+}

--- a/CodeGen/Raspberry_PI/devices/rpi_gpio.c
+++ b/CodeGen/Raspberry_PI/devices/rpi_gpio.c
@@ -1,0 +1,223 @@
+/*
+ * Bidirectional pwm_base on Raspberry Pi module
+ *
+ * Copyright (C) 2014 Pavel Pisa <pisa@cmp.felk.cvut.cz>
+ * Copyright (C) 2014 Radek Meciar
+ *
+ * Department of Control Engineering
+ * Faculty of Electrical Engineering
+ * Czech Technical University in Prague (CTU)
+ *
+ * Next exception is granted in addition to GPL.
+ * Instantiating or linking compiled version of this code
+ * to produce an application image/executable, does not
+ * by itself cause the resulting application image/executable
+ * to be covered by the GNU General Public License.
+ * This exception does not however invalidate any other reasons
+ * why the executable file might be covered by the GNU Public License.
+ * Publication of enhanced or derived S-function files is required
+ * although.
+ */
+
+#include "rpi_gpio.h"
+
+/*Based on bachelor thesis work Meciar Radek: Motor control with Raspberry Pi board and Linux*/
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+typedef enum rpi_hw_types {
+    RPI_HW_TYPE_ERROR = -1,
+    RPI_HW_TYPE_UNKNOWN = 0,
+    RPI_HW_TYPE_RPI1,
+    RPI_HW_TYPE_RPI2,
+} rpi_hw_types_t;
+
+typedef struct rpi_hw_types_map {
+    rpi_hw_types_t hw_code;
+    const char    *hw_text;
+} rpi_hw_types_map_t;
+
+const rpi_hw_types_map_t rpi_hw_types_map[] = {
+    {RPI_HW_TYPE_RPI1, "BCM2708"},
+    {RPI_HW_TYPE_RPI2, "BCM2709"},
+    {0, NULL},
+};
+
+#define RPI1_PER_BASE	0x20000000	/* registers common base address */
+#define RPI2_PER_BASE	0x3F000000	/* registers common base address */
+#define RPI_GPIO_OFFS 	(0x200000)	/* gpio_base registers base address */
+#define RPI_PWM_OFFS	(0x20C000)	/* pwm_base registers base address */
+#define RPI_CLK_OFFS	(0x101000)	/* clk_base register base address */
+
+#define PAGE_SIZE 	(4*1024)
+#define BLOCK_SIZE	(4*1024)
+
+rpi_hw_types_t rpi_hw_type = RPI_HW_TYPE_UNKNOWN;
+rpi_registers_mapping_t rpi_registers_mapping;
+
+/* Based on infromation from: http://elinux.org/RPi_Low-level_peripherals */
+
+static int rpi_gpio_fnc_setup(unsigned gpio, unsigned fnc)
+{
+    volatile unsigned *reg;
+    unsigned mask;
+
+    if (gpio >= 32)
+        return -1;
+
+    mask = 7 << ((gpio % 10) * 3);
+    fnc = fnc << ((gpio % 10) * 3);
+    fnc &= mask;
+    reg = rpi_registers_mapping.gpio_base + (gpio /10);
+
+    if ((*reg & mask) != fnc) {
+      *reg &= ~mask;
+      *reg |= fnc;
+    }
+    return 0;
+}
+
+/* Configure gpio_base pin for input */
+int rpi_gpio_direction_input(unsigned gpio)
+{
+    return rpi_gpio_fnc_setup(gpio, 0);
+}
+
+/* Configure gpio_base pin for output */
+int rpi_gpio_direction_output(unsigned gpio, int value)
+{
+    if (gpio >= 32)
+        return -1;
+
+    rpi_gpio_set_value(gpio, value);
+    if (rpi_gpio_fnc_setup(gpio, 1) < 0)
+        return -1;
+    rpi_gpio_set_value(gpio, value);
+    return 0;
+}
+
+/* Configure gpio_base pin for alternate function */
+int rpi_gpio_alt_fnc(unsigned gpio, int alt_fnc)
+{
+    return rpi_gpio_fnc_setup(gpio, alt_fnc <= 3? alt_fnc + 4: alt_fnc == 4? 3: 2);
+}
+
+rpi_hw_types_t rpi_peripheral_find_hw_type(void)
+{
+    FILE *f_cpuinfo;
+    char *line = NULL;
+    size_t line_cap = 0;
+    size_t line_len;
+    const char *p = "Unknown";
+    const rpi_hw_types_map_t *tm;
+
+    if (rpi_hw_type != RPI_HW_TYPE_UNKNOWN)
+        return rpi_hw_type;
+    return RPI_HW_TYPE_RPI2;
+
+    f_cpuinfo = fopen("/proc/cpuinfo", "r");
+    if (f_cpuinfo == NULL)
+        return RPI_HW_TYPE_ERROR;
+
+    while ((line_len = getline(&line, &line_cap, f_cpuinfo)) != -1) {
+        if (strncmp(line, "Hardware", 8) == 0) {
+            if (line[line_len - 1] == '\n') {
+                line[line_len - 1] = 0;
+            }
+            p = line + 8;
+            while (*p && isblank(*p))
+                p++;
+            if (*p != ':')
+                continue;
+            p++;
+            while (*p && isblank(*p))
+                p++;
+            for (tm = rpi_hw_types_map; tm->hw_text; tm++) {
+                if (!strcmp(p, tm->hw_text)) {
+                    rpi_hw_type = tm->hw_code;
+                }
+            }
+        }
+    }
+
+    fclose(f_cpuinfo);
+
+    if (line != NULL)
+        free(line);
+
+    return rpi_hw_type;
+}
+
+/*
+peripheral_registers_map:
+
+Maps registers into virtual address space and sets  *gpio_base, *pwm_base, *clk_base poiners
+*/
+int rpi_peripheral_registers_map(void)
+{
+    rpi_hw_types_t hw_type;
+    uintptr_t per_base;
+    rpi_registers_mapping_t *rrmap = &rpi_registers_mapping;
+    if (rrmap->mapping_initialized)
+        return rrmap->mapping_initialized;
+
+    rrmap->mapping_initialized = -1;
+
+    hw_type = rpi_peripheral_find_hw_type();
+
+    if ((hw_type == RPI_HW_TYPE_ERROR) ||
+        (hw_type == RPI_HW_TYPE_UNKNOWN))
+        return -1;
+
+    if (hw_type == RPI_HW_TYPE_RPI1)
+        per_base = RPI1_PER_BASE;
+    else if (hw_type == RPI_HW_TYPE_RPI2)
+        per_base = RPI2_PER_BASE;
+    else
+        return -1;
+
+    if ((rrmap->mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
+        return -1;
+    }
+
+    rrmap->gpio_map = mmap(NULL, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED,
+                           rrmap->mem_fd, per_base + RPI_GPIO_OFFS);
+
+    if (rrmap->gpio_map == MAP_FAILED) {
+        return -1;
+    }
+
+    rrmap->gpio_base = (volatile unsigned *)rrmap->gpio_map;
+
+    rrmap->pwm_map = mmap(NULL, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED,
+                          rrmap->mem_fd, per_base + RPI_PWM_OFFS);
+
+    if (rrmap->pwm_map == MAP_FAILED) {
+        return -1;
+    }
+
+    rrmap->pwm_base = (volatile unsigned *)rrmap->pwm_map;
+
+    rrmap->clk_map = mmap(NULL, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED,
+                          rrmap->mem_fd, per_base + RPI_CLK_OFFS);
+
+    if (rrmap->clk_map == MAP_FAILED) {
+        return -1;
+    }
+
+    rrmap->clk_base = (volatile unsigned *)rrmap->clk_map;
+
+    close(rrmap->mem_fd);
+
+    rrmap->mapping_initialized = 1;
+
+    return rrmap->mapping_initialized;
+} /* peripheral_registers_map */

--- a/CodeGen/Raspberry_PI/devices/rpi_spimc.c
+++ b/CodeGen/Raspberry_PI/devices/rpi_spimc.c
@@ -1,0 +1,286 @@
+/*
+  Communication with Raspberry Pi equipped by 3-phase
+  motor driver and RPI-MI-1 FPGA board designed
+  by Petr Porazil for PiKRON company.
+  The VHDL design by Martin Prudek.
+
+  (C) 2015 by Martin Prudek prudemar@fel.cvut.cz
+  (C) 2015 by Pavel Pisa pisa@cmp.felk.cvut.cz
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <linux/types.h>
+#include <linux/spi/spidev.h>
+
+#include "rpi_spimc.h"
+
+#define SPIMC_INDEX_BITS 12
+#define SPIMC_INDEX_MASK ((1 << SPIMC_INDEX_BITS) - 1)
+
+static uint8_t spimc_mode = 0;
+static uint8_t spimc_bits = 8;
+static uint32_t spimc_speed = 500000;
+static uint16_t spimc_delay = 0;
+
+static void pabort(const char *s)
+{
+        perror(s);
+        abort();
+}
+
+int spimc_transfer(spimc_state_t *spimcst)
+{
+	uint8_t *tx = spimcst->tx_buf;
+	uint8_t *rx = spimcst->rx_buf;
+	int ret;
+	uint32_t pwm1, pwm2, pwm3;
+	uint32_t idx;
+	int32_t  idxdiff;
+
+	memset(tx, 0, SPIMC_TRANSFER_SIZE);
+	memset(rx, 0, SPIMC_TRANSFER_SIZE);
+
+	/*Data format:
+	 * rx[0] - bity 127 downto 120 the first income bit..127
+	 * rx[1] - bity 119 downto 112
+	 * rx[2] - bity 111 downto 104
+	 * rx[3] - bity 103 downto 96
+	 * tx[4] - bity 95 downto 88
+	 * tx[5] - bity 87 downto 80
+	 * tx[6] - bity 79 downto 72
+	 * tx[7] - bity 71 downto 64
+	 * tx[8] - bity 63 downto 56
+	 * tx[9] - bity 55 downto 48
+	 * tx[10] - bity 47 downto 40
+	 * tx[11] - bity 39 downto 32
+	 * tx[12] - bity 31 downto 24
+	 * tx[13] - bity 23 downto 16
+	 * tx[14] - bity 15 downto 8
+	 * tx[15] - bity 7 downto 0
+	 *
+	 * bit 127 - ADC reset
+	 * bit 126 - enable PWM1
+	 * bit 125 - enable PWM2
+	 * bit 124 - enable PWM3
+	 * bit 123 - shutdown1
+	 * bit 122 - shutdown2
+	 * bit 121 - shutdown3
+	 * 	.
+	 * bits 47 .. 32 - match PWM1
+	 * bits 31 .. 16 - match PWM2
+	 * bits 15 .. 0  - match PWM3
+	 */
+
+	pwm1 = spimcst->pwm[0];
+	pwm2 = spimcst->pwm[1];
+	pwm3 = spimcst->pwm[2];
+
+	tx[0] = 0;
+	if (pwm1 & SPIMC_PWM_ENABLE)
+	  tx[0] |= 1 << 6;
+	if (pwm1 & SPIMC_PWM_SHUTDOWN)
+	  tx[0] |= 1 << 3;
+	if (pwm2 & SPIMC_PWM_ENABLE)
+	  tx[0] |= 1 << 5;
+	if (pwm2 & SPIMC_PWM_SHUTDOWN)
+	  tx[0] |= 1 << 2;
+	if (pwm3 & SPIMC_PWM_ENABLE)
+	  tx[0] |= 1 << 4;
+	if (pwm3 & SPIMC_PWM_SHUTDOWN)
+	  tx[0] |= 1 << 1;
+
+	pwm1 &= SPIMC_PWM_VALUE_m;
+	pwm2 &= SPIMC_PWM_VALUE_m;
+	pwm3 &= SPIMC_PWM_VALUE_m;
+
+	/* keep the cap*/
+	if (pwm1 > 2047) pwm1 = 2047;
+	if (pwm2 > 2047) pwm2 = 2047;
+	if (pwm3 > 2047) pwm3 = 2047;
+
+	/*pwm1*/
+	tx[10] = pwm1 >> 8;   /*MSB*/
+	tx[11] = pwm1 & 0xff; /*LSB*/
+
+	/*pwm2*/
+	tx[12] = pwm2 >> 8;   /*MSB*/
+	tx[13] = pwm2 & 0xff; /*LSB*/
+
+	/*pwm3*/
+	tx[14] = pwm3 >> 8;   /*MSB*/
+	tx[15] = pwm3 & 0xff; /*LSB*/
+
+	struct spi_ioc_transfer tr = {
+		.tx_buf = (uintptr_t)tx,
+		.rx_buf = (uintptr_t)rx,
+		.len = SPIMC_TRANSFER_SIZE,
+		.delay_usecs = spimc_delay,
+		.speed_hz = spimc_speed,
+		.bits_per_word = spimc_bits,
+	};
+
+	ret = ioctl(spimcst->spi_fd, SPI_IOC_MESSAGE(1), &tr);
+	if (ret < 1)
+		return -1;
+
+	/*prichozi data:
+	 * rx[0] - bity 127 downto 120 the first income bit..127
+	 * rx[1] - bity 119 downto 112
+	 * rx[2] - bity 111 downto 104
+	 * rx[3] - bity 103 downto 96
+	 * rx[4] - bity 95 downto 88
+	 * rx[5] - bity 87 downto 80
+	 * rx[6] - bity 79 downto 72
+	 * rx[7] - bity 71 downto 64
+	 * rx[8] - bity 63 downto 56
+	 * rx[9] - bity 55 downto 48
+	 * rx[10] - bity 47 downto 40
+	 * rx[11] - bity 39 downto 32
+	 * rx[12] - bity 31 downto 24
+	 * rx[13] - bity 23 downto 16
+	 * rx[14] - bity 15 downto 8
+	 * rx[15] - bity 7 downto 0	the last income bit..0
+	 */
+
+	/* position from IRC counter */
+	spimcst->act_pos = ((uint32_t)rx[0] << 24) |
+			   ((uint32_t)rx[1] << 16) |
+			   ((uint32_t)rx[2] << 8) |
+			   ((uint32_t)rx[3] << 0);
+
+	/*halove sondy
+	 * hal1 - bit95
+	 * hal2 - bit94
+	 * hal3 - bit93
+	 */
+	spimcst->hal_sensors = ((0x80 & rx[4]) >> 7) |
+                               ((0x40 & rx[4]) >> 5) |
+                               ((0x20 & rx[4]) >> 3);
+
+	/* index position
+	 * bits 92 downto 81
+	 * 	92..88 in rx[4] last 5 bits (from left)
+	 * 	87..81 in rx[5] first 7 bits (from left)
+	 */
+	idx = 0x1F & rx[4];
+	idx <<= 8;
+	idx |= 0xFE & rx[5];
+	idx >>= 1;
+
+	if ((idx ^ spimcst->index_pos) & SPIMC_INDEX_MASK) {
+		idxdiff = (idx - spimcst->act_pos +
+		           (1 << (SPIMC_INDEX_BITS - 1))) & SPIMC_INDEX_MASK;
+		idxdiff -= 1 << (SPIMC_INDEX_BITS - 1);
+		idx = spimcst->act_pos + idxdiff;
+		spimcst->index_pos = idx;
+		spimcst->index_occur += 1;
+	}
+
+	/* current measurments count
+	 * bits 80 downto 72
+	 * bit 80 in rx[5]
+	 * bits 79..72 in rx[6]
+	 */
+
+	spimcst->curadc_sqn = 0x01 & rx[5];
+	spimcst->curadc_sqn <<= 8;
+	spimcst->curadc_sqn |= rx[6];
+
+
+	/** currents
+	 * ch2 - bits 71 downto 48
+	 * 	71..64 in rx[7] - all byte
+	 * 	63..56 in rx[8] - all byte
+	 * 	55..48 in rx[9] - all byte
+	 * ch0 - bits 47 downto 24
+	 * 	47..40 in rx[10] - all byte
+	 * 	39..32 in rx[11] - all byte
+	 * 	31..24 in rx[12] - all byte
+	 * ch1 - bits 23 downto 0
+	 * 	23..16 in rx[13] - all byte
+	 * 	15..8 in rx[14] - all byte
+	 * 	7..0 in rx[15] - all byte
+	 */
+
+	spimcst->curadc_cumsum[2] = rx[7];
+	spimcst->curadc_cumsum[2] <<= 8;
+	spimcst->curadc_cumsum[2] |= rx[8];
+	spimcst->curadc_cumsum[2] <<= 8;
+	spimcst->curadc_cumsum[2] |= rx[9];
+
+	spimcst->curadc_cumsum[0] = rx[10];
+	spimcst->curadc_cumsum[0] <<= 8;
+	spimcst->curadc_cumsum[0] |= rx[11];
+	spimcst->curadc_cumsum[0] <<= 8;
+	spimcst->curadc_cumsum[0] |=rx [12];
+
+	spimcst->curadc_cumsum[1] = rx[13];
+	spimcst->curadc_cumsum[1] <<= 8;
+	spimcst->curadc_cumsum[1] |= rx[14];
+	spimcst->curadc_cumsum[1] <<= 8;
+	spimcst->curadc_cumsum[1] |= rx[15];
+
+	return 0;
+}
+
+int spimc_init(spimc_state_t *spimcst)
+{
+	int ret = 0;
+	int fd;
+
+	spimcst->spi_fd = -1;
+
+	fd = open(spimcst->spi_dev, O_RDWR);
+	if (fd < 0) {
+		pabort("can't open device");
+	}
+	printf("device open\n");
+	/*
+	 * spi spimc_mode
+	 */
+	ret = ioctl(fd, SPI_IOC_WR_MODE, &spimc_mode);
+	if (ret == -1)
+		pabort("can't set spi mode");
+
+	ret = ioctl(fd, SPI_IOC_RD_MODE, &spimc_mode);
+	if (ret == -1)
+		pabort("can't get spi mode");
+
+	/*
+	 * bits per word
+	 */
+	ret = ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &spimc_bits);
+	if (ret == -1)
+		pabort("can't set bits per word");
+
+	ret = ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &spimc_bits);
+	if (ret == -1)
+		pabort("can't get bits per word");
+
+	/*
+	 * max spimc_speed hz
+	 */
+	ret = ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &spimc_speed);
+	if (ret == -1)
+		pabort("can't set max speed hz");
+
+	ret = ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &spimc_speed);
+	if (ret == -1)
+		pabort("can't get max speed hz");
+
+	printf("spi spimc_mode: %d\n", spimc_mode);
+	printf("bits per word: %d\n", spimc_bits);
+	printf("delay: %d\n", spimc_delay);
+	printf("max spimc_speed: %d Hz (%d KHz)\n", spimc_speed, spimc_speed/1000);
+
+	spimcst->spi_fd = fd;
+
+	return ret;
+}

--- a/CodeGen/Raspberry_PI/include/rpi_gpclk.h
+++ b/CodeGen/Raspberry_PI/include/rpi_gpclk.h
@@ -1,0 +1,11 @@
+#ifndef _RPI_GPCLK_H
+#define _RPI_GPCLK_H
+
+#define RPI_GPCLK_PLLD_500_MHZ  0  /*500 MHz*/
+#define RPI_GPCLK_OSC_19_MHZ_2  1  /*19.2 MHz*/
+#define RPI_GPCLK_HDMI_216_MHZ  2  /*216 MHz*/
+#define RPI_GPCLK_PLLC_1000_MHZ 3  /*1000 MHz, changes with overclock*/
+
+int rpi_gpclk_setup(int chan, int source, int div_int, int div_frac);
+
+#endif /*_RPI_GPCLK_H*/

--- a/CodeGen/Raspberry_PI/include/rpi_gpio.h
+++ b/CodeGen/Raspberry_PI/include/rpi_gpio.h
@@ -1,0 +1,46 @@
+#ifndef _RPI_GPIO_H
+#define _RPI_GPIO_H
+
+typedef struct rpi_registers_mapping_t {
+    int mapping_initialized;
+    int mem_fd;
+    void *gpio_map;
+    void *pwm_map;
+    void *clk_map;
+    volatile unsigned *gpio_base;
+    volatile unsigned *pwm_base;
+    volatile unsigned *clk_base;
+} rpi_registers_mapping_t;
+
+extern rpi_registers_mapping_t rpi_registers_mapping;
+
+#define GPIO_SET (*(rpi_registers_mapping.gpio_base+7))
+#define GPIO_CLR (*(rpi_registers_mapping.gpio_base+10))
+#define GPIO_INP (*(rpi_registers_mapping.gpio_base+13))
+
+static inline int rpi_gpio_get_value(unsigned gpio)
+{
+    return GPIO_INP & (1 << gpio)? 1: 0;
+}
+
+/* Set gpio pin output set to specifies level */
+static inline void rpi_gpio_set_value(unsigned gpio, int value)
+{
+    if (value)
+       GPIO_SET = 1 << gpio;
+    else
+       GPIO_CLR = 1 << gpio;
+}
+
+/* Configure gpio_base pin for input */
+int rpi_gpio_direction_input(unsigned gpio);
+
+/* Configure gpio_base pin for output */
+int rpi_gpio_direction_output(unsigned gpio, int value);
+
+/* Configure gpio_base pin for alternate function */
+int rpi_gpio_alt_fnc(unsigned gpio, int alt_fnc);
+
+int rpi_peripheral_registers_map(void);
+
+#endif /*_RPI_BIDIRPWM_H*/

--- a/CodeGen/Raspberry_PI/include/rpi_spimc.h
+++ b/CodeGen/Raspberry_PI/include/rpi_spimc.h
@@ -1,0 +1,36 @@
+#ifndef _RPI_SPIMC_H
+#define _RPI_SPIMC_H
+
+#include <stdint.h>
+
+#define SPIMC_TRANSFER_SIZE 16
+#define SPIMC_CHAN_COUNT    3
+
+#define SPIMC_PWM_VALUE_m   0x0ffff
+#define SPIMC_PWM_ENABLE    0x10000
+#define SPIMC_PWM_SHUTDOWN  0x20000
+
+typedef struct spimc_state_t {
+  char     *spi_dev;
+  int      spi_fd;
+  uint32_t pwm[SPIMC_CHAN_COUNT];
+  uint32_t act_pos;
+  uint32_t index_pos;
+  uint32_t index_occur;
+  uint32_t pos_offset;
+  int32_t  curadc_val[SPIMC_CHAN_COUNT];
+  int32_t  curadc_offs[SPIMC_CHAN_COUNT];
+  uint8_t  hal_sensors;
+  uint16_t curadc_sqn;
+  uint16_t curadc_sqn_last;
+  uint32_t curadc_cumsum[SPIMC_CHAN_COUNT];
+  uint32_t curadc_cumsum_last[SPIMC_CHAN_COUNT];
+  uint8_t tx_buf[SPIMC_TRANSFER_SIZE];
+  uint8_t rx_buf[SPIMC_TRANSFER_SIZE];
+} spimc_state_t;
+
+int spimc_init(spimc_state_t *spimcst);
+
+int spimc_transfer(spimc_state_t *spimcst);
+
+#endif /*_RPI_SPIMC_H*/

--- a/CodeGen/nuttx/devices/Makefile
+++ b/CodeGen/nuttx/devices/Makefile
@@ -48,6 +48,8 @@ ifeq ($(CONFIG_SPI),y)
 SRCALL += heater.c
 SRCALL += RLC.c
 SRCALL += DCMOT.c
+SRCALL += nuttx_p3m_spi.c
+SRCALL += pm_mc1_spi.c
 endif
 
 ifeq ($(CONFIG_SENSORS_DHTXX),y)

--- a/CodeGen/nuttx/devices/nuttx_p3m_spi.c
+++ b/CodeGen/nuttx/devices/nuttx_p3m_spi.c
@@ -1,0 +1,208 @@
+/*
+COPYRIGHT (C) 2022  Dion Beqiri (beqirdio@fel.cvut.cz)
+
+Description: C-code for driving 3-Phase Motor with MCU running NuttX OS
+
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* supporting files for SPI on NuttX */
+#include "pm_mc1_spi.h"
+
+/* parameters index definition */
+
+const unsigned char pxmc_lpc_bdc_hal_pos_table[8] =
+{
+  [0] = 0xff,
+  [7] = 0xff,
+  [1] = 0, /*0*/
+  [5] = 1, /*1*/
+  [4] = 2, /*2*/
+  [6] = 3, /*3*/
+  [2] = 4, /*4*/
+  [3] = 5, /*5*/
+};
+
+/*  INITIALIZATION FUNCTION  */
+static void init(python_block *block)
+{
+  spimc_state_t *spimcst;
+
+  block->ptrPar = NULL;
+
+  spimcst = malloc(sizeof(*spimcst));
+  if (spimcst == NULL) {
+      fprintf(stderr, "malloc spimcst failed");
+      return;
+  }
+  memset(spimcst, sizeof(*spimcst), 0);
+
+  spimcst->spi_dev = "/dev/spi2";
+
+  if (spimc_init(spimcst) < 0) {
+      fprintf(stderr, "spimc_init spimcst failed");
+      return;
+  }
+
+  block->ptrPar = (void*) spimcst;
+
+  spimc_transfer(spimcst);
+
+  // Initialize conditions
+
+  spimcst->curadc_offs[0] = 0; /*2072*/
+  spimcst->curadc_offs[1] = 0; /*2077*/
+  spimcst->curadc_offs[2] = 0; /*2051*/
+
+  spimcst->pos_offset = -spimcst->act_pos;
+
+}
+
+/*  INPUT/OUTPUT  FUNCTION  */
+static void inout(python_block *block)
+{
+  double *pwm_val[3] = {block->u[0], block->u[1], block->u[2]};
+  double *pwm_en[3] = {block->u[3], block->u[4], block->u[5]};
+
+  spimc_state_t *spimcst = (spimc_state_t *)block->ptrPar;
+  int i;
+  double pwm;
+
+  spimcst->curadc_sqn_last = spimcst->curadc_sqn;
+
+  for (i = 0; i < SPIMC_CHAN_COUNT; i++)
+      spimcst->curadc_cumsum_last[i] = spimcst->curadc_cumsum[i];
+
+  for (i = 0; i < SPIMC_CHAN_COUNT; i++) {
+      if (pwm_en[i][0]) {
+          pwm = pwm_val[i][0] * 2048;
+          if (pwm > 2047)
+              pwm = 2047;
+          if (pwm < 0)
+              pwm = 0;
+          spimcst->pwm[i] = (uint32_t)pwm | SPIMC_PWM_ENABLE;
+      } else {
+          spimcst->pwm[i] = 0 | SPIMC_PWM_SHUTDOWN;
+      }
+  }
+
+  spimc_transfer(spimcst);
+
+  /* Update outputs */
+  double *cur_adc[3] = {block->y[0], block->y[1], block->y[2]};
+  double *irc_pos = block->y[3];
+  double *irc_idx = block->y[4];
+  double *irc_idx_occ = block->y[5];
+  double *hal_sec = block->y[6];
+
+  uint32_t curadc_sqn_diff;
+  uint32_t curadc_val_diff;
+  int diff_to_last_fl = 0;
+ #if 0
+  static unsigned long sqn_accum;
+  static unsigned long sqn_accum_over;
+  static unsigned long runs;
+  static unsigned long runs_over;
+  static unsigned long runs_miss;
+  static unsigned int hist[512];
+ #endif
+  curadc_sqn_diff = spimcst->curadc_sqn;
+  if (diff_to_last_fl) {
+    curadc_sqn_diff -= spimcst->curadc_sqn_last;
+    curadc_sqn_diff &= 0x1ff;
+  }
+
+  if ((curadc_sqn_diff > 1) && (curadc_sqn_diff <= 450)) {
+      for (i = 0; i < SPIMC_CHAN_COUNT; i++) {
+          curadc_val_diff = spimcst->curadc_cumsum[i];
+          if (diff_to_last_fl) {
+            curadc_val_diff -= spimcst->curadc_cumsum_last[i];
+            curadc_val_diff &= 0xffffff;
+          }
+          cur_adc[i][0] = (double)curadc_val_diff / (double)curadc_sqn_diff -
+                          (double)spimcst->curadc_offs[i];
+      }
+     #if 0
+      runs++;
+      sqn_accum += curadc_sqn_diff;
+     #endif
+  }
+ #if 0
+  else {
+      if (curadc_sqn_diff) {
+        sqn_accum_over += curadc_sqn_diff;
+        runs_over++;
+      } else runs_miss++;
+  }
+
+  hist[curadc_sqn_diff]++;
+  if (runs >= 1000) {
+    fprintf(stderr, "aver sqn diff %ld runs %ld\n", sqn_accum / runs, runs);
+    if (runs_over)
+      fprintf(stderr, "over sqn diff %ld runs %ld\n", sqn_accum_over / runs_over, runs_over);
+    if (runs_miss)
+      fprintf(stderr, "missed runs %ld\n", runs_miss);
+    for (i = 0; i < 512; i++) {
+      fprintf(stderr, " %d", hist[i]);
+      hist[i] = 0;
+    }
+    fprintf(stderr, "\n");
+    runs = 0;
+    runs_over = 0;
+    runs_miss = 0;
+    sqn_accum = 0;
+    sqn_accum_over = 0;
+  }
+ #endif
+
+  irc_pos[0] = (double)(spimcst->act_pos + spimcst->pos_offset);
+  irc_idx[0] = (double)(spimcst->index_pos + spimcst->pos_offset);
+  irc_idx_occ[0] = (double)spimcst->index_occur;
+  hal_sec[0] = (double)pxmc_lpc_bdc_hal_pos_table[spimcst->hal_sensors];
+
+
+}
+
+/*  TERMINATION FUNCTION  */
+static void end(python_block *block)
+{
+  spimc_state_t *spimcst = (spimc_state_t *)block->ptrPar;
+
+  if (spimcst != NULL) {
+      block->ptrPar = NULL;
+      free(spimcst);
+  }
+
+}
+
+void nuttx_p3m_spi(int flag, python_block *block)
+{
+  if (flag==CG_OUT){          /* input / output */
+    inout(block);
+  }
+  else if (flag==CG_END){     /* termination */
+    end(block);
+  }
+  else if (flag ==CG_INIT){    /* initialisation */
+    init(block);
+  }
+}

--- a/CodeGen/nuttx/devices/pm_mc1_spi.c
+++ b/CodeGen/nuttx/devices/pm_mc1_spi.c
@@ -1,0 +1,264 @@
+/*
+  Communication with NuttX device equipped by 3-phase
+  motor driver and RPI-MI-1 FPGA board designed
+  by Petr Porazil for PiKRON company.
+  The VHDL design by Martin Prudek.
+  Original code from RPi version:
+  (C) 2015 by Martin Prudek prudemar@fel.cvut.cz
+  (C) 2015 by Pavel Pisa pisa@cmp.felk.cvut.cz
+  Edited for NuttX:
+  (C) 2022 by Dion Beqiri beqirdio@fel.cvut.cz
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <nuttx/spi/spi_transfer.h>
+#include <nuttx/spi/spi.h>
+
+#include "pm_mc1_spi.h"
+
+#define SPIMC_INDEX_BITS 12
+#define SPIMC_INDEX_MASK ((1 << SPIMC_INDEX_BITS) - 1)
+
+static uint8_t spimc_mode = 0;
+static uint8_t spimc_bits = 8;
+static uint32_t spimc_speed = 500000;
+static uint16_t spimc_delay = 0;
+
+static void pabort(const char *s)
+{
+        perror(s);
+        abort();
+}
+
+int spimc_transfer(spimc_state_t *spimcst)
+{
+	uint8_t *tx = spimcst->tx_buf;
+	uint8_t *rx = spimcst->rx_buf;
+	int ret;
+	uint32_t pwm1, pwm2, pwm3;
+	uint32_t idx;
+	int32_t  idxdiff;
+
+	memset(tx, 0, SPIMC_TRANSFER_SIZE);
+	memset(rx, 0, SPIMC_TRANSFER_SIZE);
+
+	/*Data format:
+	 * rx[0] - bity 127 downto 120 the first income bit..127
+	 * rx[1] - bity 119 downto 112
+	 * rx[2] - bity 111 downto 104
+	 * rx[3] - bity 103 downto 96
+	 * tx[4] - bity 95 downto 88
+	 * tx[5] - bity 87 downto 80
+	 * tx[6] - bity 79 downto 72
+	 * tx[7] - bity 71 downto 64
+	 * tx[8] - bity 63 downto 56
+	 * tx[9] - bity 55 downto 48
+	 * tx[10] - bity 47 downto 40
+	 * tx[11] - bity 39 downto 32
+	 * tx[12] - bity 31 downto 24
+	 * tx[13] - bity 23 downto 16
+	 * tx[14] - bity 15 downto 8
+	 * tx[15] - bity 7 downto 0
+	 *
+	 * bit 127 - ADC reset
+	 * bit 126 - enable PWM1
+	 * bit 125 - enable PWM2
+	 * bit 124 - enable PWM3
+	 * bit 123 - shutdown1
+	 * bit 122 - shutdown2
+	 * bit 121 - shutdown3
+	 * 	.
+	 * bits 47 .. 32 - match PWM1
+	 * bits 31 .. 16 - match PWM2
+	 * bits 15 .. 0  - match PWM3
+	 */
+
+	pwm1 = spimcst->pwm[0];
+	pwm2 = spimcst->pwm[1];
+	pwm3 = spimcst->pwm[2];
+
+	tx[0] = 0;
+	if (pwm1 & SPIMC_PWM_ENABLE)
+	  tx[0] |= 1 << 6;
+	if (pwm1 & SPIMC_PWM_SHUTDOWN)
+	  tx[0] |= 1 << 3;
+	if (pwm2 & SPIMC_PWM_ENABLE)
+	  tx[0] |= 1 << 5;
+	if (pwm2 & SPIMC_PWM_SHUTDOWN)
+	  tx[0] |= 1 << 2;
+	if (pwm3 & SPIMC_PWM_ENABLE)
+	  tx[0] |= 1 << 4;
+	if (pwm3 & SPIMC_PWM_SHUTDOWN)
+	  tx[0] |= 1 << 1;
+
+	pwm1 &= SPIMC_PWM_VALUE_m;
+	pwm2 &= SPIMC_PWM_VALUE_m;
+	pwm3 &= SPIMC_PWM_VALUE_m;
+
+	/* keep the cap*/
+	if (pwm1 > 2047) pwm1 = 2047;
+	if (pwm2 > 2047) pwm2 = 2047;
+	if (pwm3 > 2047) pwm3 = 2047;
+
+	/*pwm1*/
+	tx[10] = pwm1 >> 8;   /*MSB*/
+	tx[11] = pwm1 & 0xff; /*LSB*/
+
+	/*pwm2*/
+	tx[12] = pwm2 >> 8;   /*MSB*/
+	tx[13] = pwm2 & 0xff; /*LSB*/
+
+	/*pwm3*/
+	tx[14] = pwm3 >> 8;   /*MSB*/
+	tx[15] = pwm3 & 0xff; /*LSB*/
+
+  struct spi_trans_s transs = {
+    .delay = (useconds_t)spimc_delay,
+    .nwords = SPIMC_TRANSFER_SIZE,
+    .txbuffer = (void*)tx,
+    .rxbuffer = (void*)rx
+  };
+
+	struct spi_sequence_s tr = {
+		.dev = 23,
+		.mode = 0,
+		.nbits = spimc_bits,
+    .ntrans = 1,
+    .frequency = spimc_speed,
+    .trans = &transs
+	};
+
+	ret = ioctl(spimcst->spi_fd, SPIIOC_TRANSFER, &tr);
+	if (ret < 0)
+		return -1;
+
+	/*prichozi data:
+	 * rx[0] - bity 127 downto 120 the first income bit..127
+	 * rx[1] - bity 119 downto 112
+	 * rx[2] - bity 111 downto 104
+	 * rx[3] - bity 103 downto 96
+	 * rx[4] - bity 95 downto 88
+	 * rx[5] - bity 87 downto 80
+	 * rx[6] - bity 79 downto 72
+	 * rx[7] - bity 71 downto 64
+	 * rx[8] - bity 63 downto 56
+	 * rx[9] - bity 55 downto 48
+	 * rx[10] - bity 47 downto 40
+	 * rx[11] - bity 39 downto 32
+	 * rx[12] - bity 31 downto 24
+	 * rx[13] - bity 23 downto 16
+	 * rx[14] - bity 15 downto 8
+	 * rx[15] - bity 7 downto 0	the last income bit..0
+	 */
+
+	/* position from IRC counter */
+	spimcst->act_pos = ((uint32_t)rx[0] << 24) |
+			   ((uint32_t)rx[1] << 16) |
+			   ((uint32_t)rx[2] << 8) |
+			   ((uint32_t)rx[3] << 0);
+
+	/*halove sondy
+	 * hal1 - bit95
+	 * hal2 - bit94
+	 * hal3 - bit93
+	 */
+	spimcst->hal_sensors = ((0x80 & rx[4]) >> 7) |
+                               ((0x40 & rx[4]) >> 5) |
+                               ((0x20 & rx[4]) >> 3);
+
+	/* index position
+	 * bits 92 downto 81
+	 * 	92..88 in rx[4] last 5 bits (from left)
+	 * 	87..81 in rx[5] first 7 bits (from left)
+	 */
+	idx = 0x1F & rx[4];
+	idx <<= 8;
+	idx |= 0xFE & rx[5];
+	idx >>= 1;
+
+	if ((idx ^ spimcst->index_pos) & SPIMC_INDEX_MASK) {
+		idxdiff = (idx - spimcst->act_pos +
+		           (1 << (SPIMC_INDEX_BITS - 1))) & SPIMC_INDEX_MASK;
+		idxdiff -= 1 << (SPIMC_INDEX_BITS - 1);
+		idx = spimcst->act_pos + idxdiff;
+		spimcst->index_pos = idx;
+		spimcst->index_occur += 1;
+	}
+
+	/* current measurments count
+	 * bits 80 downto 72
+	 * bit 80 in rx[5]
+	 * bits 79..72 in rx[6]
+	 */
+
+	spimcst->curadc_sqn = 0x01 & rx[5];
+	spimcst->curadc_sqn <<= 8;
+	spimcst->curadc_sqn |= rx[6];
+
+
+	/** currents
+	 * ch2 - bits 71 downto 48
+	 * 	71..64 in rx[7] - all byte
+	 * 	63..56 in rx[8] - all byte
+	 * 	55..48 in rx[9] - all byte
+	 * ch0 - bits 47 downto 24
+	 * 	47..40 in rx[10] - all byte
+	 * 	39..32 in rx[11] - all byte
+	 * 	31..24 in rx[12] - all byte
+	 * ch1 - bits 23 downto 0
+	 * 	23..16 in rx[13] - all byte
+	 * 	15..8 in rx[14] - all byte
+	 * 	7..0 in rx[15] - all byte
+	 */
+
+	spimcst->curadc_cumsum[2] = rx[7];
+	spimcst->curadc_cumsum[2] <<= 8;
+	spimcst->curadc_cumsum[2] |= rx[8];
+	spimcst->curadc_cumsum[2] <<= 8;
+	spimcst->curadc_cumsum[2] |= rx[9];
+
+	spimcst->curadc_cumsum[0] = rx[10];
+	spimcst->curadc_cumsum[0] <<= 8;
+	spimcst->curadc_cumsum[0] |= rx[11];
+	spimcst->curadc_cumsum[0] <<= 8;
+	spimcst->curadc_cumsum[0] |=rx [12];
+
+	spimcst->curadc_cumsum[1] = rx[13];
+	spimcst->curadc_cumsum[1] <<= 8;
+	spimcst->curadc_cumsum[1] |= rx[14];
+	spimcst->curadc_cumsum[1] <<= 8;
+	spimcst->curadc_cumsum[1] |= rx[15];
+
+	return 0;
+}
+
+int spimc_init(spimc_state_t *spimcst)
+{
+	int ret = 0;
+	int fd;
+
+	spimcst->spi_fd = -1;
+
+	fd = open(spimcst->spi_dev, O_RDWR);
+	if (fd < 0) {
+		pabort("can't open device");
+	}
+	printf("device open\n");
+
+
+	printf("spi spimc_mode: %d\n", spimc_mode);
+	printf("bits per word: %d\n", spimc_bits);
+	printf("delay: %d\n", spimc_delay);
+	printf("max spimc_speed: %d Hz (%d KHz)\n", spimc_speed, spimc_speed/1000);
+
+	spimcst->spi_fd = fd;
+
+	return ret;
+}

--- a/CodeGen/nuttx/devices/pm_mc1_spi.h
+++ b/CodeGen/nuttx/devices/pm_mc1_spi.h
@@ -1,0 +1,36 @@
+#ifndef _NUTTX_SPIMC_H
+#define _NUTTX_SPIMC_H
+
+#include <stdint.h>
+
+#define SPIMC_TRANSFER_SIZE 16
+#define SPIMC_CHAN_COUNT    3
+
+#define SPIMC_PWM_VALUE_m   0x0ffff
+#define SPIMC_PWM_ENABLE    0x10000
+#define SPIMC_PWM_SHUTDOWN  0x20000
+
+typedef struct spimc_state_t {
+  char     *spi_dev;
+  int      spi_fd;
+  uint32_t pwm[SPIMC_CHAN_COUNT];
+  uint32_t act_pos;
+  uint32_t index_pos;
+  uint32_t index_occur;
+  uint32_t pos_offset;
+  int32_t  curadc_val[SPIMC_CHAN_COUNT];
+  int32_t  curadc_offs[SPIMC_CHAN_COUNT];
+  uint8_t  hal_sensors;
+  uint16_t curadc_sqn;
+  uint16_t curadc_sqn_last;
+  uint32_t curadc_cumsum[SPIMC_CHAN_COUNT];
+  uint32_t curadc_cumsum_last[SPIMC_CHAN_COUNT];
+  uint8_t tx_buf[SPIMC_TRANSFER_SIZE];
+  uint8_t rx_buf[SPIMC_TRANSFER_SIZE];
+} spimc_state_t;
+
+int spimc_init(spimc_state_t *spimcst);
+
+int spimc_transfer(spimc_state_t *spimcst);
+
+#endif /*_NUTTX_SPIMC_H*/

--- a/resources/blocks/blocks/NuttX/P3MotorNuttx.xblk
+++ b/resources/blocks/blocks/NuttX/P3MotorNuttx.xblk
@@ -1,0 +1,1 @@
+{"lib": "NuttX", "name": "Phase3Motor", "ip": 6, "op": 7, "stin": 0, "stout": 0, "icon": "MOT", "params": "P3MotNuttxBlk", "help": "Block for controlling 3-Phase DC Motor using SPI connection in NuttX\n\n\n\n"}

--- a/resources/blocks/blocks/Raspberry/P3Motor.xblk
+++ b/resources/blocks/blocks/Raspberry/P3Motor.xblk
@@ -1,0 +1,1 @@
+{"lib": "Raspberry", "name": "Phase3Motor", "ip": 6, "op": 7, "stin": 0, "stout": 0, "icon": "MOT", "params": "P3MotBlk", "help": "Block for controlling 3-Phase DC Motor using SPI connection in RPi\n\n\n\n"}

--- a/resources/blocks/rcpBlk/NuttX/P3MotNuttxBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/P3MotNuttxBlk.py
@@ -1,0 +1,20 @@
+from supsisim.RCPblk import RCPblk
+
+def P3MotNuttxBlk(pin, pout):
+    """
+
+    Call:   P3MotNuttxBlk(pin,pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+       blk: RCPblk
+
+    """
+
+    blk = RCPblk('nuttx_p3m_spi', pin, pout, [0,0], 0, [], [])
+    return blk

--- a/resources/blocks/rcpBlk/Raspberry/P3MotBlk.py
+++ b/resources/blocks/rcpBlk/Raspberry/P3MotBlk.py
@@ -1,0 +1,20 @@
+from supsisim.RCPblk import RCPblk
+
+def P3MotBlk(pin, pout):
+    """
+
+    Call:   P3MotBlk(pin,pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+       blk: RCPblk
+
+    """
+
+    blk = RCPblk('P3M_spi', pin, pout, [0,0], 0, [], [])
+    return blk


### PR DESCRIPTION
These are all new blocks which are made for controlling a 3-Phase DC motor by utilizing an SPI connection with a hardware driver which uses FPGA.

One commit is only for the support given for NuttX, tested on the ESP32C3 RISC-V board.

The other commit is for support of RaspberryPi board for the same operations.

There is also one minor addition to the Makefile for the /nuttx/devices folder which includes more support files for the
"CONFIG_SPI=y" condition. 

Links to the documentation of previous implementation of the code on Simulink which was originally made
for the RaspberryPi can be seen here: 
https://gitlab.fel.cvut.cz/otrees/nuttx-demos/-/wikis/pmsm-control

The new code was developed for the purpose of making a Demonstration for my Bachelor's thesis. The .dgm files will be pushed to the "pysimCoder-examples" repository in order to simply "Plug and Play" the block for direct usage on a 3-Phase Motor.