### PR TITLE
Mz apo shv

### DIFF
--- a/CodeGen/linux_mz_apo/devices/Makefile
+++ b/CodeGen/linux_mz_apo/devices/Makefile
@@ -1,11 +1,14 @@
-all: lib install
-reduced: lib install
+all: dependencies lib install
+reduced: dependencies lib install
 
-LIB = libPipyblk.a
+LIB = libpyblk.a
 GENERIC_INC = $(PYSUPSICTRL)/CodeGen/Common/include
 TARGET_INC = ../include
-
+INCLUDE = -I$(GENERIC_INC) -I$(TARGET_INC)
 COMMON_DIR = $(PYSUPSICTRL)/CodeGen/Common
+EXT_LIBS = $(PYSUPSICTRL)/ExtLibs
+
+.PHONY: all dependencies clean install
 
 SRCALL = $(wildcard *.c)
 SRCALL += $(wildcard $(COMMON_DIR)/CAN_dev/*.c)
@@ -14,7 +17,16 @@ SRCALL += $(wildcard $(COMMON_DIR)/Faulhaber_dev/*.c)
 SRCALL += $(wildcard $(COMMON_DIR)/Maxon_dev/*.c)
 SRCALL += $(wildcard $(COMMON_DIR)/posix/*.c)
 
-OBJ = $(notdir $(SRCALL:.c=.o))
+ifeq ($(SHV),1)
+EXT_SHV_LIB = $(EXT_LIBS)/libshv/libshvchainpack/c
+
+SRCALL += $(EXT_SHV_LIB)/cchainpack.c $(EXT_SHV_LIB)/ccpcp.c \
+					$(EXT_SHV_LIB)/ccpcp_convert.c $(EXT_SHV_LIB)/ccpon.c \
+					$(EXT_SHV_LIB)/pack_double.c
+SRCALL += $(EXT_LIBS)/ulut/ulut/ul_gavlprim.c
+SRCALL += $(EXT_LIBS)/ulut/ulut/ul_gsacust.c
+SRCALL += $(wildcard $(COMMON_DIR)/shv/*.c)
+endif
 
 CWD = $(shell pwd)
 
@@ -26,7 +38,22 @@ AR = arm-linux-gnueabihf-ar
 OBJEX = $(SRC:.c=.o)
 INCLUDE =  -I$(GENERIC_INC) -I$(TARGET_INC)
 CC_FLAGS = -c $(DBG) $(INCLUDE)
+ifeq ($(SHV),1)
+CC_FLAGS += -I$(COMMON_DIR)/shv/include
+CC_FLAGS += -I$(EXT_LIBS)/libshv/libshvchainpack/c
+CC_FLAGS += -I$(EXT_LIBS)/ulut
+endif
 CC_FLAGS += -D CG_WITH_ENV_HOST_ADDR
+
+dependencies:
+ifeq ($(SHV),1)
+	cd $(EXT_LIBS) && if [ ! -e libshv ]; then git clone https://github.com/silicon-heaven/libshv; fi
+	cd $(EXT_LIBS) && if [ ! -e ulut ]; then git clone https://git.code.sf.net/p/ulan/ulut; fi
+endif
+	cd $(PYSUPSICTRL)/CodeGen/LinuxRT/devices
+
+SRC=$(filter-out $(EXCLUDE),$(SRCALL))
+OBJ = $(notdir $(SRCALL:.c=.o))
 
 %.o: %.c
 	$(CC) $(CC_FLAGS) $<
@@ -46,6 +73,32 @@ CC_FLAGS += -D CG_WITH_ENV_HOST_ADDR
 %.o: $(COMMON_DIR)/posix/%.c
 	$(CC) $(CC_FLAGS) $<
 
+ifeq ($(SHV),1)
+cchainpack.o: $(EXT_SHV_LIB)/cchainpack.c
+	$(CC) $(CC_FLAGS) $<
+
+ccpcp.o: $(EXT_SHV_LIB)/ccpcp.c
+	$(CC) $(CC_FLAGS) $<
+
+ccpcp_convert.o: $(EXT_SHV_LIB)/ccpcp_convert.c
+	$(CC) $(CC_FLAGS) $<
+
+ccpon.o: $(EXT_SHV_LIB)/ccpon.c
+	$(CC) $(CC_FLAGS) $<
+
+pack_double.o: $(EXT_SHV_LIB)/pack_double.c
+	$(CC) $(CC_FLAGS) $<
+
+ul_gavlprim.o: $(EXT_LIBS)/ulut/ulut/ul_gavlprim.c
+	$(CC) $(CC_FLAGS) $<
+
+ul_gsacust.o: $(EXT_LIBS)/ulut/ulut/ul_gsacust.c
+	$(CC) $(CC_FLAGS) $<
+
+%.o: $(COMMON_DIR)/shv/%.c
+	$(CC) $(CC_FLAGS) $<
+endif
+
 lib: $(OBJ)
 	$(AR) -r $(LIB) $(OBJ)
 
@@ -53,4 +106,6 @@ install:
 	mv $(LIB) ../lib
 
 clean:
+	rm -rf $(EXT_LIBS)/libshv
+	rm -rf $(EXT_LIBS)/ulut
 	rm -f $(LIB) $(OBJ)

--- a/CodeGen/src/linux_main_rt.c
+++ b/CodeGen/src/linux_main_rt.c
@@ -189,6 +189,8 @@ char *parse_string(char ** str, int parse_char)
 static void proc_opt(int argc, char *argv[])
 {
   int i;
+  char *t;
+
   while((i=getopt(argc,argv,"D:ef:hp:vVw"))!=-1){
     switch(i){
     case 'h':
@@ -220,7 +222,7 @@ static void proc_opt(int argc, char *argv[])
       }
       break;
     case 'D':
-      char *t = parse_string(&optarg, '=');
+      t = parse_string(&optarg, '=');
       if (t == NULL)
         {
           break;

--- a/CodeGen/templates/rt_mz_apo.tmf
+++ b/CodeGen/templates/rt_mz_apo.tmf
@@ -7,6 +7,10 @@ LIBDIR  = $(PYCODEGEN)/linux_mz_apo/lib
 INCDIR  = $(PYCODEGEN)/linux_mz_apo/include
 COMMON_INCDIR = $(PYCODEGEN)/Common/include
 
+SHV_INC = $(PYCODEGEN)/Common/shv/include
+ULUT_INC = $(PYSUPSICTRL)/ExtLibs/ulut
+EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c
+
 RM = rm -f
 FILES_TO_CLEAN = *.o $(MODEL)
 
@@ -20,7 +24,16 @@ OBJSSTAN = $(MAIN).o $(MODEL).o $(ADD_FILES)
 
 CFLAGS = $(CC_OPTIONS) -O2 -I$(INCDIR) -I$(COMMON_INCDIR) $(C_FLAGS) -DMODEL=$(MODEL)
 
-LIB = $(LIBDIR)/libPipyblk.a
+CFLAGS += -I$(SHV_INC)
+ifneq ($(wildcard $(ULUT_INC)),)
+ULUT_INC = $(PYSUPSICTRL)/ExtLibs/ulut
+CFLAGS += -I$(ULUT_INC)
+endif
+ifneq ($(wildcard $(EXT_SHV_INC)),)
+CFLAGS += -I$(EXT_SHV_INC)
+endif
+
+LIB = $(LIBDIR)/libpyblk.a
 
 $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	cp $< .


### PR DESCRIPTION
Hello Roberto,

Michal Lenc's SHV support propagated into MZ_APO template and libraries.

pysimCoder has been installed to our server supporting NFS read only loop to all
laboratories at our department. Generation tested to run on the MZ_APO
system

  https://cw.fel.cvut.cz/wiki/_media/courses/b35apo/en/semestral/mz_apo-datasheet-en.pdf

with DC motor peripheral **dcsimpledrv**. Its VHDL sources are available there

  https://gitlab.fel.cvut.cz/canbus/zynq/zynq-can-sja1000-top/-/tree/microzed-2dc/system/ip/dcsimpledrv_1.0

Best wishes,

Pavel
