### PR TITLE
Enhancement of NuttX Encoder block and addition of two blocks for PMSM control

### DIFF
--- a/CodeGen/Common/common_dev/hall3ph2sec.c
+++ b/CodeGen/Common/common_dev/hall3ph2sec.c
@@ -1,0 +1,97 @@
+/*
+COPYRIGHT (C) 2022  Michal Lenc (michallenc@seznam.cz)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+
+static const signed char hall_pos_table[8] =
+{
+  [0] = -1,
+  [7] = -1,
+  [1] =  0,    /*0*/
+  [5] =  1,    /*1*/
+  [4] =  2,    /*2*/
+  [6] =  3,    /*3*/
+  [2] =  4,    /*4*/
+  [3] =  5,    /*5*/
+};
+
+static const signed char hall_pos_table_inverted[8] =
+{
+  [0] = -1,
+  [7] = -1,
+  [1] =  0,    /*0*/
+  [5] =  5,    /*1*/
+  [4] =  4,    /*2*/
+  [6] =  3,    /*3*/
+  [2] =  2,    /*4*/
+  [3] =  1,    /*5*/
+};
+
+/****************************************************************************
+ * Name: hall2sec
+ *
+ * Description:
+ *   Converts signal from 3 phase HALL sensor (used in PMSM for example) to
+ *   a sector number.
+ *
+ ****************************************************************************/
+
+void hall3ph2sec(int Flag, python_block *block)
+{
+  double *hall_a = block->u[0];
+  double *hall_b = block->u[1];
+  double *hall_c = block->u[2];
+  double *pos = block->y[0];
+  double *error = block->y[1];
+
+  int *intPar = block->intPar;
+  double mode = intPar[0];
+  int pos_new;
+  int hall = 0;
+
+  switch(Flag)
+    {
+      case CG_OUT:
+      case CG_INIT:
+      case CG_END:
+        hall |= hall_a[0] != 0;
+        hall |= (hall_b[0] != 0) << 1;
+        hall |= (hall_c[0] != 0) << 2;
+        if (mode == 0)
+          {
+            pos_new = hall_pos_table[hall];
+          }
+        else
+          {
+            pos_new = hall_pos_table_inverted[hall];
+          }
+
+        if (pos_new != -1)
+          {
+            pos[0] = pos_new;
+            error[0] = 0;
+          }
+        else
+          {
+            error[0] = 1;
+          }
+        break;
+      default:
+        break;
+    }
+}

--- a/CodeGen/Common/common_dev/pmsm_align.c
+++ b/CodeGen/Common/common_dev/pmsm_align.c
@@ -1,0 +1,99 @@
+/*
+COPYRIGHT (C) 2022  Michal Lenc (michallenc@seznam.cz)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795029
+#endif
+
+/****************************************************************************
+ * Name: pmsm_align
+ *
+ * Description:
+ *  This function computes the electric angle of PMSM. There are four inputs
+ *  required:
+ *     - Hall sector number
+ *     - Encoder position
+ *     - Last position of encoder's index
+ *     - Index count
+ *
+ *  The function takes those inputs and determines whether the HALL sensors
+ *  or encoder are used for the motor's angle. HALL sensors are used until
+ *  the encoder hits its index.
+ *
+ ****************************************************************************/
+
+void pmsm_align(int Flag, python_block *block)
+{
+  double *pos_hall = block->u[0];
+  double *pos_enc = block->u[1];
+  double *pos_indx = block->u[2];
+  double *indx_cnt = block->u[3];
+  double *angle_out = block->y[0];
+  double *align_reset = block->u[4];
+
+  int indx_change = 0;
+
+  double *realPar = block->realPar;
+  int *intPar = block->intPar;
+  double hall_offset = realPar[0];
+  double encoder_res = realPar[1];
+  double angle_offset = realPar[2];
+
+  switch(Flag)
+    {
+      case CG_INIT:
+        intPar[0] = 0;
+      case CG_OUT:
+        if (align_reset[0] == 1)
+          {
+            intPar[0] = 0;
+          }
+        if (intPar[1] != indx_cnt[0])
+          {
+            indx_change = 1;
+          }
+
+        intPar[1] = indx_cnt[0];
+        if (intPar[0] < 2)
+          {
+            intPar[0] += 1;
+          }
+        else
+          {
+            if (indx_change)
+              {
+                intPar[0] = 3;
+              }
+          }
+      case CG_END:
+        if (intPar[0] != 3)
+          {
+            angle_out[0] = (pos_hall[0] + hall_offset) * 3.14/3;
+          }
+        else
+          {
+            angle_out[0] = (pos_enc[0] - pos_indx[0])*M_PI*2/encoder_res + angle_offset;
+          }
+        break;
+      default:
+        break;
+    }
+}

--- a/resources/blocks/Icons/HALL_2_SEC.svg
+++ b/resources/blocks/Icons/HALL_2_SEC.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="HALL_2_SEC.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1852"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="8.0338983"
+     inkscape:cy="23.694915"
+     inkscape:window-x="68"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.277061"
+     y="19.949152"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       x="32.277061"
+       y="19.949152"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32">HALL TO</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.209267"
+     y="33.406776"
+     id="text3361-3"><tspan
+       sodipodi:role="line"
+       x="32.209267"
+       y="33.406776"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32-6">SECTORS</tspan></text>
+</svg>

--- a/resources/blocks/Icons/PMSM_Align.svg
+++ b/resources/blocks/Icons/PMSM_Align.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   width="64"
+   height="48"
+   viewBox="0 0 64 48"
+   sodipodi:docname="PMSM_Align.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1852"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="8.0338983"
+     inkscape:cy="23.694915"
+     inkscape:window-x="68"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3357" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.277061"
+     y="19.949152"
+     id="text3361"><tspan
+       sodipodi:role="line"
+       x="32.277061"
+       y="19.949152"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32">PMSM</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="32.209267"
+     y="33.406776"
+     id="text3361-3"><tspan
+       sodipodi:role="line"
+       x="32.209267"
+       y="33.406776"
+       style="font-size:12px;line-height:1.25;font-family:sans-serif;text-align:center;text-anchor:middle"
+       id="tspan32-6">Align</tspan></text>
+</svg>

--- a/resources/blocks/blocks/Math/hall3ph2sec.xblk
+++ b/resources/blocks/blocks/Math/hall3ph2sec.xblk
@@ -1,0 +1,11 @@
+{
+  "lib": "math",
+  "name": "Hall to 6 Sectors",
+  "ip": 3,
+  "op": 2,
+  "stin": 0,
+  "stout": 0,
+  "icon": "HALL_2_SEC",
+  "params": "hall3ph2secBlk|Inverted: 0:int",
+  "help": "Converstion of 3 phase Hall to 6 sectors.\nInverted: 1 (yes), 0 (no).\n"
+}

--- a/resources/blocks/blocks/Math/pmsm_align.xblk
+++ b/resources/blocks/blocks/Math/pmsm_align.xblk
@@ -1,0 +1,11 @@
+{
+  "lib": "math",
+  "name": "PMSM Align",
+  "ip": 5,
+  "op": 1,
+  "stin": 0,
+  "stout": 0,
+  "icon": "PMSM_Align",
+  "params": "pmsm_alignBlk|Hall Offset:2:double|IRC per period:1000:double|Angle Offset:0:double",
+  "help": "Alignment of PMSM based on input from HALL sensors and encoder angle.\n\nParameters:\n Hall offset: offset between HALL sectors and motor angle\n Encoder resolution: IRC per period\n Angle offset: offset between encoder angle and motor angle\n\nInputs:\n Hall sector number\n Encoder position\n Last position of encoder's index\n Index count\n\nThe block takes those inputs and determines whether the HALL sensors or encoder are used for the motor's angle. HALL sensors are used until the encoder hits its index.\n\n"
+}

--- a/resources/blocks/blocks/NuttX/nuttxENC.xblk
+++ b/resources/blocks/blocks/NuttX/nuttxENC.xblk
@@ -4,8 +4,8 @@
   "ip": 0,
   "op": 1,
   "stin": 0,
-  "stout": 0,
+  "stout": 1,
   "icon": "ENC",
   "params": "nuttxENCBlk|Port:'/dev/qe0'|Resolution:500:double| reset counter [1 yes]:1:int",
-  "help": "Parameters\nPort: device name\nResolution: Encoder resolution\nReset: 1=yes, 0 = no\n\n\n"
+  "help": "This block can have 1 or 3 outputs. Only position is returned if one output is used, position, index and index cound is returned if 3 outputs are selected.\n\nParameters\nPort: device name\nResolution: Encoder resolution (can be 0 if no resolution required)\nReset: 1=yes, 0 = no\n\n\n"
 }

--- a/resources/blocks/rcpBlk/Math/hall3ph2secBlk.py
+++ b/resources/blocks/rcpBlk/Math/hall3ph2secBlk.py
@@ -1,0 +1,22 @@
+from supsisim.RCPblk import RCPblk
+
+def hall3ph2secBlk(pin, pout, Inverted):
+    """
+
+    Call:   hall3ph2secBlk(pin, pout, Gains)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+       Inverted : 1 if inverted table is used
+
+    Returns
+    -------
+        blk  : RCPblk
+
+    """
+
+    blk = RCPblk('hall3ph2sec',pin,pout,[0,0],1,[],[Inverted])
+    return blk
+

--- a/resources/blocks/rcpBlk/Math/pmsm_alignBlk.py
+++ b/resources/blocks/rcpBlk/Math/pmsm_alignBlk.py
@@ -1,0 +1,20 @@
+from supsisim.RCPblk import RCPblk
+
+def pmsm_alignBlk(pin, pout, hallOffset, IRCperPeriod, angleOffset):
+    """
+
+    Call:   pmsm_alignBlk(pin, pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+        blk  : RCPblk
+
+    """
+
+    blk = RCPblk('pmsm_align',pin,pout,[0,0],1,[hallOffset, IRCperPeriod, angleOffset],[0, 0])
+    return blk

--- a/resources/blocks/rcpBlk/NuttX/nuttxENCBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttxENCBlk.py
@@ -20,5 +20,8 @@ def nuttxENCBlk(pout, port, res, reset):
 
     """
 
+    if (size(pout) != 1 and size(pout) != 3):
+       raise ValueError("NuttxENC: Number of outputs (%i) should be 1 or 3" % (size(pout)))
+
     blk = RCPblk('nuttxENC', [], pout, [0,0], 0, [4*res], [reset, 0], port)
     return blk


### PR DESCRIPTION
This PR consists of three commits.

**Enhancement of NuttX Encoder block**
- added support for QEIOC_GETINDEX call (implemented to NuttX mainline in [8e2b4576](https://github.com/apache/incubator-nuttx/commit/8e2b4576bf422b3ef1be1f6a75068d3d974f117e), currently supported only with iMXRT MCU)
- QEIOC_GETINDEX returns encoder position, index position and index count with one IOCTL call

**Hall 2 Sectors block**
- This block converts 3 Hall signals to 6 sectors (3 bits)

**PMSM Align block**
- PMSM Align block computes the electric angle of PMSM. Based on the inputs (hall sector number, encoder position, index, index count) it determines whether the HALL sensors or encoder are used for the motor's angle. HALL sensors are used until the encoder hits its index.