### PR TITLE
shv:  rewite ls to work without malloc and adapt for new broker

### DIFF
--- a/CodeGen/Common/shv/include/shv_com.h
+++ b/CodeGen/Common/shv/include/shv_com.h
@@ -32,12 +32,19 @@ typedef struct shv_con_ctx {
   struct shv_node *root;
 } shv_con_ctx_t;
 
+typedef struct shv_str_list_it_t shv_str_list_it_t;
+
+struct shv_str_list_it_t {
+   const char * (*get_next_entry)(shv_str_list_it_t *it, int reset_to_first);
+};
+
 shv_con_ctx_t *shv_com_init(struct shv_node *root);
 void shv_com_end(shv_con_ctx_t *ctx);
 void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num);
 void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num);
 void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str);
 void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str, const char **str);
+void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str, shv_str_list_it_t *str_it);
 void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, const char *msg);
 void shv_send_ping(shv_con_ctx_t *shv_ctx);
 

--- a/CodeGen/Common/shv/include/shv_tree.h
+++ b/CodeGen/Common/shv/include/shv_tree.h
@@ -76,6 +76,38 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
 GSA_CUST_DEC(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
+typedef struct shv_node_list_it_t {
+  shv_node_list_t *node_list;
+  union {
+    shv_node_t *gavl_next_node;
+    int gsa_next_indx;
+  } list_it;
+} shv_node_list_it_t;
+
+void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it);
+void shv_node_list_it_reset(shv_node_list_it_t *it);
+shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it);
+
+static inline int
+shv_node_list_count(shv_node_list_t *node_list)
+{
+  if (node_list->mode & SHV_NLIST_MODE_GSA)
+    {
+      return node_list->list.gsa.root.count;
+    }
+  else
+    {
+      return node_list->list.gavl.count;
+    }
+}
+
+typedef struct shv_node_list_names_it_t {
+  shv_str_list_it_t str_it;
+  shv_node_list_it_t list_it;
+} shv_node_list_names_it_t;
+
+void shv_node_list_names_it_init(shv_node_list_t *list, shv_node_list_names_it_t *names_it);
+
 /* Public functions definition */
 
 int shv_node_process(shv_con_ctx_t *shv_ctx, int rid, const char * met, const char * path);

--- a/CodeGen/Common/shv/shv_methods.c
+++ b/CodeGen/Common/shv/shv_methods.c
@@ -91,50 +91,21 @@ const shv_dmap_t shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_it
 int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
 {
   int count;
-  const char **array;
-  shv_node_t *item_child;
-  int i;
+  shv_node_list_names_it_t names_it;
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 
-  /* Get item's children */
+  /* Get item's children count */
 
-  if (item->children.mode & SHV_NLIST_MODE_GSA)
-    {
-      count = item->children.list.gsa.root.count;
-    }
-  else
-    {
-      count = item->children.list.gavl.count;
-    }
-
-  array = malloc(count * sizeof(char *));
+  count = shv_node_list_count(&item->children);
 
   /* Find each child */
 
-  if (item->children.mode & SHV_NLIST_MODE_GSA)
-    {
-      for (i = 0; i < count; i++)
-        {
-          item_child = shv_node_list_gsa_at(&item->children, i);
-          array[i] = item_child->name;
-        }
-    }
-  else
-    {
-      i = 0;
-      gavl_cust_for_each(shv_node_list_gavl, &item->children, item_child)
-        {
-          array[i] = item_child->name;
-          i++;
-        }
-    }
+  shv_node_list_names_it_init(&item->children, &names_it);
 
   /* And send it */
 
-  shv_send_str_list(shv_ctx, rid, i, array);
-
-  free(array);
+  shv_send_str_list_it(shv_ctx, rid, count, &names_it.str_it);
 
   return 0;
 }

--- a/CodeGen/Common/shv/shv_tree.c
+++ b/CodeGen/Common/shv/shv_tree.c
@@ -85,6 +85,113 @@ shv_node_t *shv_node_find(shv_node_t *node, const char * path)
 }
 
 /****************************************************************************
+ * Name: shv_node_list_it_reset
+ *
+ * Description:
+ *   Reset position to the first node in the shv_node_list.
+ *
+ ****************************************************************************/
+
+void shv_node_list_it_reset(shv_node_list_it_t *it)
+{
+  if (it->node_list->mode & SHV_NLIST_MODE_GSA)
+    {
+      it->list_it.gsa_next_indx = shv_node_list_gsa_first_indx(it->node_list);
+    }
+  else
+    {
+      it->list_it.gavl_next_node = shv_node_list_gavl_first(it->node_list);
+    }
+}
+
+/****************************************************************************
+ * Name: shv_node_list_it_init
+ *
+ * Description:
+ *   Setup iterator for consecutive access to the list nodes.
+ *
+ ****************************************************************************/
+
+void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it)
+{
+  it->node_list = list;
+  shv_node_list_it_reset(it);
+}
+
+/****************************************************************************
+ * Name: shv_node_list_it_next
+ *
+ * Description:
+ *   Get next node from the shv_node_list according to iterator position.
+ *
+ ****************************************************************************/
+
+shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it)
+{
+  shv_node_t *node;
+
+  if (it->node_list->mode & SHV_NLIST_MODE_GSA)
+    {
+       node = shv_node_list_gsa_at(it->node_list, it->list_it.gsa_next_indx);
+       it->list_it.gsa_next_indx++;
+    }
+  else
+    {
+      node = it->list_it.gavl_next_node;
+      it->list_it.gavl_next_node = shv_node_list_gavl_next(it->node_list, node);
+    }
+  return node;
+}
+
+/****************************************************************************
+ * Name: shv_node_list_names_get_next
+ *
+ * Description:
+ *   Helper function for the names as string list iterator.
+ *
+ ****************************************************************************/
+
+static const char *shv_node_list_names_get_next(shv_str_list_it_t *it,
+                                                int reset_to_first)
+{
+  shv_node_list_names_it_t *names_it;
+  shv_node_t *node;
+
+  names_it = UL_CONTAINEROF(it, shv_node_list_names_it_t, str_it);
+
+  if (reset_to_first)
+    {
+      shv_node_list_it_reset(&names_it->list_it);
+    }
+
+  node = shv_node_list_it_next(&names_it->list_it);
+
+  if (node != NULL)
+    {
+      return node->name;
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+/****************************************************************************
+ * Name: shv_node_list_names_it_init
+ *
+ * Description:
+ *   Setup iterator for consecutive access to the node list children names.
+ *
+ ****************************************************************************/
+
+void shv_node_list_names_it_init(shv_node_list_t *list,
+                                 shv_node_list_names_it_t *names_it)
+{
+  shv_node_list_it_init(list, &names_it->list_it);
+  names_it->str_it.get_next_entry = shv_node_list_names_get_next;
+}
+
+/****************************************************************************
  * Name: shv_tree_add_child
  *
  * Description:


### PR DESCRIPTION
The broker has been updated when we have discussed about
latest changes and as result of the broker update there
problem appeared. New broker version uses standard
map field within header metadata. This is according SHV
original design but simple C implementation was not
able to skip this kind of unused metadata in received
header parsing.