### PR TITLE
RT scope utility: ensure correct handling of TCP stream with unaligned chunks

### DIFF
--- a/BlockEditor/RTScope.py
+++ b/BlockEditor/RTScope.py
@@ -150,22 +150,27 @@ class tcp_rcvServer(threading.Thread):
             ret = QMessageBox.warning(self.mainw, '', 'Port already in use, please close it',
                                       QMessageBox.Ok, QMessageBox.Ok)
             return
-        
+
         while self.mainw.ServerActive==1:
             conn, addr = self.port.accept()
+            buf = bytearray()
             while True:
+                chunk = bytearray(conn.recv(L - len(buf)))
+                if (len(chunk) == 0):
+                    conn.close()
+                    break
+                buf.extend(chunk)
+                if len(buf) < L:
+                    continue
+
                 self.mainw.timebase.append(T)
                 T+=1
 
                 if len(self.mainw.timebase) > self.mainw.Hist:
                     self.mainw.timebase = self.mainw.timebase[-self.mainw.Hist:]
 
-                buf = bytearray(conn.recv(L))
-                if (len(buf) == 0):
-                    conn.close()
-                    break
-
                 data = self.st.unpack(buf)
+                buf = bytearray()
             
                 if self.mainw.ckSaveData.isChecked():
                     self.mainw.saveData(data)

--- a/CodeGen/src/linux_main_rt.c
+++ b/CodeGen/src/linux_main_rt.c
@@ -51,7 +51,7 @@ double get_Tsamp(void)
   return(Tsamp);
 }
 
-int get_priority_for_com()
+int get_priority_for_com(void)
 {
   if (prio < 0)
     {
@@ -241,6 +241,10 @@ static void proc_opt(int argc, char *argv[])
               break;
             }
           setenv("SHV_BROKER_PORT", t, 1);
+        }
+      else
+        {
+          setenv(t, optarg, 1);
         }
       break;
     }

--- a/CodeGen/src/nuttx_main.c
+++ b/CodeGen/src/nuttx_main.c
@@ -239,6 +239,10 @@ static void proc_opt(int argc, char *argv[])
             }
           setenv("SHV_BROKER_PORT", t, 1);
         }
+      else
+        {
+          setenv(t, optarg, 1);
+        }
       break;
     }
   }


### PR DESCRIPTION
The TCP recv even in blocking mode is guaranteed only to wait for single byte. It can return with les bytes read than requested and if the data are delivered in packets not exactly aligned to the N * 8 bytes equivalent to configured number of signals then RT scope fails with message like

    data = self.st.unpack(buf)
    struct.error: unpack requires a buffer of 24 bytes