### PR TITLE
shv: fix compile error with incorrect include path

### DIFF
--- a/CodeGen/Common/shv/include/shv_com.h
+++ b/CodeGen/Common/shv/include/shv_com.h
@@ -1,7 +1,7 @@
 #ifndef SHV_FUNCTIONS_H
 #define SHV_FUNCTIONS_H
 
-#include <cchainpack.h>
+#include <shv/chainpack/cchainpack.h>
 
 #define SHV_BUF_LEN  1024
 #define SHV_MET_LEN  16

--- a/CodeGen/Common/shv/include/shv_methods.h
+++ b/CodeGen/Common/shv/include/shv_methods.h
@@ -3,7 +3,7 @@
 
 #include <ulut/ul_gavlcust.h>
 #include <ulut/ul_gsacust.h>
-#include <cchainpack.h>
+#include <shv/chainpack/cchainpack.h>
 #include <string.h>
 
 #include "shv_com.h"

--- a/CodeGen/Common/shv/include/shv_pysim.h
+++ b/CodeGen/Common/shv/include/shv_pysim.h
@@ -3,7 +3,7 @@
 
 #include <ulut/ul_gavlcust.h>
 #include <ulut/ul_gsacust.h>
-#include <cchainpack.h>
+#include <shv/chainpack/cchainpack.h>
 #include <string.h>
 
 extern const shv_dmap_t shv_blk_dmap;

--- a/CodeGen/Common/shv/include/shv_tree.h
+++ b/CodeGen/Common/shv/include/shv_tree.h
@@ -3,7 +3,7 @@
 
 #include <ulut/ul_gavlcust.h>
 #include <ulut/ul_gsacust.h>
-#include <cchainpack.h>
+#include <shv/chainpack/cchainpack.h>
 #include <string.h>
 
 #include "shv_com.h"

--- a/CodeGen/Common/shv/shv_com.c
+++ b/CodeGen/Common/shv/shv_com.c
@@ -30,8 +30,8 @@
 #include <math.h>
 #include <errno.h>
 
-#include <cchainpack.h>
-#include <ccpon.h>
+#include <shv/chainpack/cchainpack.h>
+#include <shv/chainpack/ccpon.h>
 
 #include "ulut/ul_utdefs.h"
 

--- a/CodeGen/linux_mz_apo/devices/Makefile
+++ b/CodeGen/linux_mz_apo/devices/Makefile
@@ -39,7 +39,7 @@ INCLUDE =  -I$(GENERIC_INC) -I$(TARGET_INC)
 CC_FLAGS = -c $(DBG) $(INCLUDE)
 ifeq ($(SHV),1)
 CC_FLAGS += -I$(COMMON_DIR)/shv/include
-CC_FLAGS += -I$(EXT_LIBS)/libshv/libshvchainpack/c
+CC_FLAGS += -I$(EXT_LIBS)/libshv/libshvchainpack/c/include
 CC_FLAGS += -I$(EXT_LIBS)/ulut
 endif
 CC_FLAGS += -D CG_WITH_ENV_HOST_ADDR

--- a/CodeGen/templates/nuttx.tmf
+++ b/CodeGen/templates/nuttx.tmf
@@ -11,7 +11,7 @@ COMMON_INCDIR = $(PYCODEGEN)/Common/include
 
 SHV_INC = $(PYCODEGEN)/Common/shv/include
 ULUT_INC = $(PYSUPSICTRL)/ExtLibs/ulut
-EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c/include/shv/chainpack
+EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c/include
 
 RM = rm -f
 FILES_TO_CLEAN = *.o $(MODEL) $(MODEL).elf $(MAIN)-builtintab.c

--- a/CodeGen/templates/rt.tmf
+++ b/CodeGen/templates/rt.tmf
@@ -15,7 +15,7 @@ TOS1A_INC  = $(PYCODEGEN)/tos1a/includes
 
 SHV_INC = $(PYCODEGEN)/Common/shv/include
 ULUT_INC = $(PYSUPSICTRL)/ExtLibs/ulut
-EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c
+EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs/libshv/libshvchainpack/c/include
 
 RM = rm -f
 FILES_TO_CLEAN = *.o $(MODEL)

--- a/CodeGen/templates/rt_mz_apo.tmf
+++ b/CodeGen/templates/rt_mz_apo.tmf
@@ -9,7 +9,7 @@ COMMON_INCDIR = $(PYCODEGEN)/Common/include
 
 SHV_INC = $(PYCODEGEN)/Common/shv/include
 ULUT_INC = $(PYSUPSICTRL)/ExtLibs/ulut
-EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c
+EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs/libshv/libshvchainpack/c/include
 
 RM = rm -f
 FILES_TO_CLEAN = *.o $(MODEL)


### PR DESCRIPTION
Actual SHV has a different location of include files. This commit follows up previous fix commits but also changes the path in .c and .h files so it follows the current SHV include standard.

The change is done for both NuttX and LinuxRT targets