### PR TITLE
CodeGen/linux_mz_apo: Add PMSM control on MZ_APO board with 3pmdrv1 board

### DIFF
--- a/CodeGen/linux_mz_apo/devices/README.md
+++ b/CodeGen/linux_mz_apo/devices/README.md
@@ -1,0 +1,2 @@
+For compilation with SHV usage you must compile the code with "SHV=1" flagy
+

--- a/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1.c
+++ b/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1.c
@@ -1,0 +1,206 @@
+/*
+COPYRIGHT (C) 2022  Dion Beqiri (beqirdio@fel.cvut.cz)
+
+Description: C-code for driving 3-Phase Motor with MCU running NuttX OS
+
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+*/
+
+#include <pyblock.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* supporting files for SPI on NuttX */
+#include "zynq_3pmdrv1_mc.h"
+
+/* parameters index definition */
+
+const unsigned char pxmc_lpc_bdc_hal_pos_table[8] =
+{
+  [0] = 0xff,
+  [7] = 0xff,
+  [1] = 0, /*0*/
+  [5] = 1, /*1*/
+  [4] = 2, /*2*/
+  [6] = 3, /*3*/
+  [2] = 4, /*4*/
+  [3] = 5, /*5*/
+};
+
+/*  INITIALIZATION FUNCTION  */
+static void init(python_block *block)
+{
+  z3pmdrv1_state_t *mcst;
+
+  block->ptrPar = NULL;
+
+  mcst = malloc(sizeof(*mcst));
+  if (mcst == NULL) {
+      fprintf(stderr, "malloc mcst failed");
+      return;
+  }
+  memset(mcst, sizeof(*mcst), 0);
+
+  if (z3pmdrv1_init(mcst) < 0) {
+      fprintf(stderr, "z3pmdrv1_init mcst failed");
+      return;
+  }
+
+  block->ptrPar = (void*) mcst;
+
+  z3pmdrv1_transfer(mcst, 1);
+
+  // Initialize conditions
+
+  mcst->curadc_offs[0] = 0; /*2072*/
+  mcst->curadc_offs[1] = 0; /*2077*/
+  mcst->curadc_offs[2] = 0; /*2051*/
+
+  mcst->pos_offset = -mcst->act_pos;
+
+}
+
+/*  INPUT/OUTPUT  FUNCTION  */
+static void inout(python_block *block)
+{
+  double *pwm_val[3] = {block->u[0], block->u[1], block->u[2]};
+  double *pwm_en[3] = {block->u[3], block->u[4], block->u[5]};
+
+  z3pmdrv1_state_t *mcst = (z3pmdrv1_state_t *)block->ptrPar;
+  int i;
+  double pwm;
+
+  mcst->curadc_sqn_last = mcst->curadc_sqn;
+
+  for (i = 0; i < Z3PMDRV1_CHAN_COUNT; i++)
+      mcst->curadc_cumsum_last[i] = mcst->curadc_cumsum[i];
+
+  for (i = 0; i < Z3PMDRV1_CHAN_COUNT; i++) {
+      if (pwm_en[i][0]) {
+          pwm = pwm_val[i][0] * 2048;
+          if (pwm > 2047)
+              pwm = 2047;
+          if (pwm < 0)
+              pwm = 0;
+          mcst->pwm[i] = (uint32_t)pwm | Z3PMDRV1_PWM_ENABLE;
+      } else {
+          mcst->pwm[i] = 0 | Z3PMDRV1_PWM_SHUTDOWN;
+      }
+  }
+
+  z3pmdrv1_transfer(mcst, 1);
+
+  /* Update outputs */
+  double *cur_adc[3] = {block->y[0], block->y[1], block->y[2]};
+  double *irc_pos = block->y[3];
+  double *irc_idx = block->y[4];
+  double *irc_idx_occ = block->y[5];
+  double *hal_sec = block->y[6];
+
+  uint32_t curadc_sqn_diff;
+  uint32_t curadc_val_diff;
+  int diff_to_last_fl = 1;
+ #if 0
+  static unsigned long sqn_accum;
+  static unsigned long sqn_accum_over;
+  static unsigned long runs;
+  static unsigned long runs_over;
+  static unsigned long runs_miss;
+  static unsigned int hist[512];
+ #endif
+  curadc_sqn_diff = mcst->curadc_sqn;
+  if (diff_to_last_fl) {
+    curadc_sqn_diff -= mcst->curadc_sqn_last;
+    curadc_sqn_diff &= 0x1ff;
+  }
+
+  if ((curadc_sqn_diff > 1) && (curadc_sqn_diff <= 450)) {
+      for (i = 0; i < Z3PMDRV1_CHAN_COUNT; i++) {
+          curadc_val_diff = mcst->curadc_cumsum[i];
+          if (diff_to_last_fl) {
+            curadc_val_diff -= mcst->curadc_cumsum_last[i];
+            curadc_val_diff &= 0xffffff;
+          }
+          cur_adc[i][0] = (double)curadc_val_diff / (double)curadc_sqn_diff -
+                          (double)mcst->curadc_offs[i];
+      }
+     #if 0
+      runs++;
+      sqn_accum += curadc_sqn_diff;
+     #endif
+  }
+ #if 0
+  else {
+      if (curadc_sqn_diff) {
+        sqn_accum_over += curadc_sqn_diff;
+        runs_over++;
+      } else runs_miss++;
+  }
+
+  hist[curadc_sqn_diff]++;
+  if (runs >= 1000) {
+    fprintf(stderr, "aver sqn diff %ld runs %ld\n", sqn_accum / runs, runs);
+    if (runs_over)
+      fprintf(stderr, "over sqn diff %ld runs %ld\n", sqn_accum_over / runs_over, runs_over);
+    if (runs_miss)
+      fprintf(stderr, "missed runs %ld\n", runs_miss);
+    for (i = 0; i < 512; i++) {
+      fprintf(stderr, " %d", hist[i]);
+      hist[i] = 0;
+    }
+    fprintf(stderr, "\n");
+    runs = 0;
+    runs_over = 0;
+    runs_miss = 0;
+    sqn_accum = 0;
+    sqn_accum_over = 0;
+  }
+ #endif
+
+  irc_pos[0] = (double)(mcst->act_pos + mcst->pos_offset);
+  irc_idx[0] = (double)(mcst->index_pos + mcst->pos_offset);
+  irc_idx_occ[0] = (double)mcst->index_occur;
+  hal_sec[0] = (double)pxmc_lpc_bdc_hal_pos_table[mcst->hal_sensors];
+
+
+}
+
+/*  TERMINATION FUNCTION  */
+static void end(python_block *block)
+{
+  z3pmdrv1_state_t *mcst = (z3pmdrv1_state_t *)block->ptrPar;
+
+  if (mcst != NULL) {
+      block->ptrPar = NULL;
+      free(mcst);
+  }
+
+}
+
+void zynq_3pmdrv1(int flag, python_block *block)
+{
+  if (flag==CG_OUT){          /* input / output */
+    inout(block);
+  }
+  else if (flag==CG_END){     /* termination */
+    end(block);
+  }
+  else if (flag ==CG_INIT){    /* initialisation */
+    init(block);
+  }
+}

--- a/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1_mc.c
+++ b/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1_mc.c
@@ -1,0 +1,241 @@
+/*
+  Communication with Zynq equipped by 3-phase
+  motor driver connected to MicroZed on MZ_APO board.
+  MZ_APO and 3-phase motor driver boards have been
+  designed by Petr Porazil for PiKRON company.
+  The Zynq VHDL design by Pavel Pisa, partially
+  inspired by previous work done together with
+  Martin Prudek.
+
+  (C) 2017 by Pavel Pisa ppisa@pikron.com
+*/
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <linux/types.h>
+#include <linux/spi/spidev.h>
+
+#include "zynq_3pmdrv1_mc.h"
+
+#define Z3PMDRV1_REG_BASE_PHYS     0x43c20000
+#define Z3PMDRV1_REG_SIZE          0x00001000
+
+#define Z3PMDRV1_REG_IRC_POS_o         0x0008
+#define Z3PMDRV1_REG_IRC_IDX_POS_o     0x000C
+
+#define Z3PMDRV1_REG_PWM1_o            0x0010
+#define Z3PMDRV1_REG_PWM2_o            0x0014
+#define Z3PMDRV1_REG_PWM3_o            0x0018
+
+#define Z3PMDRV1_REG_PWMX_VAL_m    0x00003fff
+#define Z3PMDRV1_REG_PWMX_EN_m     0x40000000
+#define Z3PMDRV1_REG_PWMX_SHDN_m   0x80000000
+
+#define Z3PMDRV1_REG_ADC_SQN_STAT_o    0x0020
+
+#define Z3PMDRV1_REG_ADSQST_SQN_m  0x000001ff
+#define Z3PMDRV1_REG_ADSQST_HAL1_m 0x00010000
+#define Z3PMDRV1_REG_ADSQST_HAL2_m 0x00020000
+#define Z3PMDRV1_REG_ADSQST_HAL3_m 0x00040000
+#define Z3PMDRV1_REG_ADSQST_ST1_m  0x00100000
+#define Z3PMDRV1_REG_ADSQST_ST2_m  0x00200000
+#define Z3PMDRV1_REG_ADSQST_ST3_m  0x00400000
+#define Z3PMDRV1_REG_ADSQST_PWST_m 0x01000000
+
+#define Z3PMDRV1_REG_ADC1_o            0x0024
+#define Z3PMDRV1_REG_ADC2_o            0x0028
+#define Z3PMDRV1_REG_ADC3_o            0x002C
+
+char *memdev="/dev/mem";
+
+static inline
+uint32_t z3pmdrv1_reg_rd(z3pmdrv1_state_t *z3pmcst, unsigned reg_offs)
+{
+	return *(volatile uint32_t*)((char*)z3pmcst->regs_base_virt + reg_offs);
+}
+
+static inline
+void z3pmdrv1_reg_wr(z3pmdrv1_state_t *z3pmcst, unsigned reg_offs, uint32_t val)
+{
+	*(volatile uint32_t*)((char*)z3pmcst->regs_base_virt + reg_offs) = val;
+}
+
+int z3pmdrv1_transfer(z3pmdrv1_state_t *z3pmcst, int flags)
+{
+	uint32_t sqn_stat;
+	uint32_t pwm1, pwm2, pwm3;
+	uint32_t pwm1_fl = 0;
+	uint32_t pwm2_fl = 0;
+	uint32_t pwm3_fl = 0;
+	uint32_t idx;
+
+	pwm1 = z3pmcst->pwm[0];
+	pwm2 = z3pmcst->pwm[1];
+	pwm3 = z3pmcst->pwm[2];
+
+	if (pwm1 & Z3PMDRV1_PWM_ENABLE)
+	  pwm1_fl |= Z3PMDRV1_REG_PWMX_EN_m;
+	if (pwm1 & Z3PMDRV1_PWM_SHUTDOWN)
+	  pwm1_fl |= Z3PMDRV1_REG_PWMX_SHDN_m;
+	if (pwm2 & Z3PMDRV1_PWM_ENABLE)
+	  pwm2_fl |= Z3PMDRV1_REG_PWMX_EN_m;
+	if (pwm2 & Z3PMDRV1_PWM_SHUTDOWN)
+	  pwm2_fl |= Z3PMDRV1_REG_PWMX_SHDN_m;
+	if (pwm3 & Z3PMDRV1_PWM_ENABLE)
+	  pwm3_fl |= Z3PMDRV1_REG_PWMX_EN_m;
+	if (pwm3 & Z3PMDRV1_PWM_SHUTDOWN)
+	  pwm3_fl |= Z3PMDRV1_REG_PWMX_SHDN_m;
+
+	pwm1 &= Z3PMDRV1_PWM_VALUE_m;
+	pwm2 &= Z3PMDRV1_PWM_VALUE_m;
+	pwm3 &= Z3PMDRV1_PWM_VALUE_m;
+
+	if (pwm1 > Z3PMDRV1_REG_PWMX_VAL_m)
+		pwm1 = Z3PMDRV1_REG_PWMX_VAL_m;
+	if (pwm2 > Z3PMDRV1_REG_PWMX_VAL_m)
+		pwm2 = Z3PMDRV1_REG_PWMX_VAL_m;
+	if (pwm3 > Z3PMDRV1_REG_PWMX_VAL_m)
+		pwm3 = Z3PMDRV1_REG_PWMX_VAL_m;
+
+	z3pmdrv1_reg_wr(z3pmcst, Z3PMDRV1_REG_PWM1_o, pwm1 | pwm1_fl);
+	z3pmdrv1_reg_wr(z3pmcst, Z3PMDRV1_REG_PWM2_o, pwm2 | pwm2_fl);
+	z3pmdrv1_reg_wr(z3pmcst, Z3PMDRV1_REG_PWM3_o, pwm3 | pwm3_fl);
+
+	z3pmcst->act_pos = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_IRC_POS_o);
+	idx = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_IRC_IDX_POS_o);
+
+	if (idx ^ z3pmcst->index_pos) {
+		z3pmcst->index_occur += 1;
+	}
+	z3pmcst->index_pos = idx;
+
+	if (flags & 1) {
+		z3pmcst->curadc_sqn_last = z3pmcst->curadc_sqn;
+		z3pmcst->curadc_cumsum_last[0] = z3pmcst->curadc_cumsum[0];
+		z3pmcst->curadc_cumsum_last[1] = z3pmcst->curadc_cumsum[1];
+		z3pmcst->curadc_cumsum_last[2] = z3pmcst->curadc_cumsum[2];
+	}
+
+	sqn_stat = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC_SQN_STAT_o);
+	z3pmcst->curadc_sqn = sqn_stat & Z3PMDRV1_REG_ADSQST_SQN_m;
+
+	z3pmcst->curadc_cumsum[2] = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC3_o);
+
+	z3pmcst->curadc_cumsum[0] = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC2_o);
+
+	z3pmcst->curadc_cumsum[1] = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC1_o);
+
+	z3pmcst->hal_sensors =
+		((sqn_stat & Z3PMDRV1_REG_ADSQST_HAL1_m)?1:0) |
+		((sqn_stat & Z3PMDRV1_REG_ADSQST_HAL2_m)?2:0) |
+		((sqn_stat & Z3PMDRV1_REG_ADSQST_HAL3_m)?4:0);
+
+	return 0;
+}
+
+
+/*
+ * The support function which returns pointer to the virtual
+ * address at which starts remapped physical region in the
+ * process virtual memory space.
+ */
+static inline
+void *map_phys_address(off_t region_base, size_t region_size, int opt_cached)
+{
+	unsigned long mem_window_size;
+	unsigned long pagesize;
+	unsigned char *mm;
+	unsigned char *mem;
+	int fd;
+
+	/*
+	 * Open a device ("/dev/mem") representing physical address space
+	 * in POSIX systems
+	 */
+	fd = open(memdev, O_RDWR | (!opt_cached? O_SYNC: 0));
+	if (fd < 0) {
+		fprintf(stderr, "cannot open %s\n", memdev);
+		return NULL;
+	}
+
+	/*
+	 * The virtual to physical address mapping translation granularity
+	 * corresponds to memory page size. This call obtains the page
+	 * size used by running operating system at given CPU architecture.
+	 * 4kB are used by Linux running on ARM, ARM64, x86 and x86_64 systems.
+	 */
+	pagesize=sysconf(_SC_PAGESIZE);
+
+	/*
+	 * Extend physical region start address and size to page size boundaries
+	 * to cover complete requested region.
+	 */
+	mem_window_size = ((region_base & (pagesize-1)) +
+			  region_size + pagesize-1) & ~(pagesize-1);
+
+	/*
+	 * Map file (in our case physical memory) range at specified offset
+	 * to virtual memory ragion/area (see VMA Linux kernel structures)
+	 * of the process.
+	 */
+	mm = mmap(NULL, mem_window_size, PROT_WRITE|PROT_READ,
+		MAP_SHARED, fd, region_base & ~(pagesize-1));
+
+	/* Report failure if the mmap is not allowed for given file or its region */
+	if (mm == MAP_FAILED) {
+		return NULL;
+	}
+
+	/*
+	 * Add offset in the page to the returned pointer for non-page-aligned
+	 * requests.
+	 */
+	mem = mm + (region_base & (pagesize-1));
+
+	return mem;
+}
+
+int z3pmdrv1_init(z3pmdrv1_state_t *z3pmcst)
+{
+	int ret = 0;
+	uint32_t sqn_stat;
+
+	if (z3pmcst->regs_base_phys == 0) {
+		z3pmcst->regs_base_phys = Z3PMDRV1_REG_BASE_PHYS;
+	}
+
+	z3pmcst->regs_base_virt = map_phys_address(z3pmcst->regs_base_phys,
+					Z3PMDRV1_REG_SIZE, 0);
+
+	if (z3pmcst->regs_base_virt == NULL) {
+		ret = -1;
+		return ret;
+	}
+
+	sqn_stat = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC_SQN_STAT_o);
+	z3pmcst->curadc_sqn = sqn_stat & Z3PMDRV1_REG_ADSQST_SQN_m;
+	z3pmcst->curadc_sqn_last = z3pmcst->curadc_sqn;
+
+	z3pmcst->curadc_cumsum[2] = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC3_o);
+
+	z3pmcst->curadc_cumsum[0] = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC2_o);
+
+	z3pmcst->curadc_cumsum[1] = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_ADC1_o);
+
+	z3pmcst->curadc_cumsum_last[0] = z3pmcst->curadc_cumsum[0];
+	z3pmcst->curadc_cumsum_last[1] = z3pmcst->curadc_cumsum[1];
+	z3pmcst->curadc_cumsum_last[2] = z3pmcst->curadc_cumsum[2];
+
+	z3pmcst->index_pos = z3pmdrv1_reg_rd(z3pmcst, Z3PMDRV1_REG_IRC_IDX_POS_o);
+
+	z3pmcst->curadc_use_diff_to_last_fl = 1;
+
+	return ret;
+}

--- a/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1_mc.h
+++ b/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1_mc.h
@@ -1,0 +1,34 @@
+#ifndef _ZYNQ_3PMDRV1_MC_H
+#define _ZYNQ_3PMDRV1_MC_H
+
+#include <stdint.h>
+
+#define Z3PMDRV1_CHAN_COUNT    3
+
+#define Z3PMDRV1_PWM_VALUE_m   0x0ffff
+#define Z3PMDRV1_PWM_ENABLE    0x40000000
+#define Z3PMDRV1_PWM_SHUTDOWN  0x80000000
+
+typedef struct z3pmdrv1_state_t {
+  uintptr_t regs_base_phys;
+  void     *regs_base_virt;
+  uint32_t pwm[Z3PMDRV1_CHAN_COUNT];
+  uint32_t act_pos;
+  uint32_t index_pos;
+  uint32_t index_occur;
+  uint32_t pos_offset;
+  int32_t  curadc_val[Z3PMDRV1_CHAN_COUNT];
+  int32_t  curadc_offs[Z3PMDRV1_CHAN_COUNT];
+  uint8_t  hal_sensors;
+  uint16_t curadc_sqn;
+  uint16_t curadc_sqn_last;
+  uint32_t curadc_cumsum[Z3PMDRV1_CHAN_COUNT];
+  uint32_t curadc_cumsum_last[Z3PMDRV1_CHAN_COUNT];
+  int      curadc_use_diff_to_last_fl;
+} z3pmdrv1_state_t;
+
+int z3pmdrv1_init(z3pmdrv1_state_t *z3pmcst);
+
+int z3pmdrv1_transfer(z3pmdrv1_state_t *z3pmcst, int flags);
+
+#endif /*_ZYNQ_3PMDRV1_MC_H*/

--- a/resources/blocks/blocks/linux_mz_apo/mz_apo_3pmdrv1.xblk
+++ b/resources/blocks/blocks/linux_mz_apo/mz_apo_3pmdrv1.xblk
@@ -1,0 +1,11 @@
+{
+  "lib": "linux_mz_apo",
+  "name": "Phase3Motor_mz_apo_3pmdrv1",
+  "ip": 6,
+  "op": 7,
+  "stin": 0,
+  "stout": 0,
+  "icon": "MOT",
+  "params": "mz_apo_3pmdrv1",
+  "help": "Block for controlling 3-Phase PMSM Motor on MZ Apo\n\n Inputs:\nu[0] to u[2] are PWM values, u[3] to u[5] are PWM enable signals \n\n  Outputs:\ny[0] to y[2] are currents from ADC (12 bit, zero in the middle, uncalibrated)\nu[3] is IRC position, u[4] is IRC idx and u[5] is IRC index occur\nu[6] is HAL sector."
+}

--- a/resources/blocks/rcpBlk/linux_mz_apo/mz_apo_3pmdrv1.py
+++ b/resources/blocks/rcpBlk/linux_mz_apo/mz_apo_3pmdrv1.py
@@ -1,0 +1,20 @@
+from supsisim.RCPblk import RCPblk
+
+def mz_apo_3pmdrv1(pin, pout):
+    """
+
+    Call:   mz_apo_3pmdrv1(pin,pout)
+
+    Parameters
+    ----------
+       pin: connected input port(s)
+       pout: connected output port(s)
+
+    Returns
+    -------
+       blk: RCPblk
+
+    """
+
+    blk = RCPblk('zynq_3pmdrv1', pin, pout, [0,0], 0, [], [])
+    return blk


### PR DESCRIPTION
Add mz_apo_3pmdrv1 block to control the PMSM motor.

Component VHDL design

https://gitlab.fel.cvut.cz/canbus/zynq/zynq-can-sja1000-top/-/tree/master/system/ip/pmsm_3pmdrv1_1.0?ref_type=heads