### PR TITLE
Replace deprecated scipy imports with numpy ones

### DIFF
--- a/BlockEditor/xblk2Blk.py
+++ b/BlockEditor/xblk2Blk.py
@@ -110,7 +110,7 @@ class MainWindow(QMainWindow, form_class):
             callingFun += self.gridLayout.itemAtPosition(n,2).widget().text() + ', '
         callingFun = callingFun.rstrip(', ') + ')'
         fun   = 'from supsisim.RCPblk import RCPblk\n'
-        fun += 'from scipy import size\n\n'
+        fun += 'from numpy import size\n\n'
         
         fun += 'def ' + callingFun + ':\n'
             

--- a/resources/blocks/rcpBlk/AR2INO/ar2inoAIBlk.py
+++ b/resources/blocks/rcpBlk/AR2INO/ar2inoAIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ar2inoAIBlk(pout, ch, Umin, Umax):
     """

--- a/resources/blocks/rcpBlk/AR2INO/ar2inoDIBlk.py
+++ b/resources/blocks/rcpBlk/AR2INO/ar2inoDIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ar2inoDIBlk(pout, ch):
     """

--- a/resources/blocks/rcpBlk/AR2INO/ar2inoDOBlk.py
+++ b/resources/blocks/rcpBlk/AR2INO/ar2inoDOBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ar2inoDOBlk(pin, ch, th):
     """

--- a/resources/blocks/rcpBlk/AR2INO/ar2inoENCBlk.py
+++ b/resources/blocks/rcpBlk/AR2INO/ar2inoENCBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ar2inoENCBlk(pout, channel, res, reset):
     """

--- a/resources/blocks/rcpBlk/AR2INO/ar2inoPWMBlk.py
+++ b/resources/blocks/rcpBlk/AR2INO/ar2inoPWMBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ar2inoPWMBlk(pin, ch, Umin, Umax):
     """

--- a/resources/blocks/rcpBlk/AR2INO/ar2inoSetupBlk.py
+++ b/resources/blocks/rcpBlk/AR2INO/ar2inoSetupBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ar2inoSetupBlk(channel, baud):
     """

--- a/resources/blocks/rcpBlk/Communication/SHVInputBlk.py
+++ b/resources/blocks/rcpBlk/Communication/SHVInputBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def SHVInputBlk(pout):
     """

--- a/resources/blocks/rcpBlk/Communication/SHVOutputBlk.py
+++ b/resources/blocks/rcpBlk/Communication/SHVOutputBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def SHVOutputBlk(pin):
     """

--- a/resources/blocks/rcpBlk/Communication/TCPsocketTxBlk.py
+++ b/resources/blocks/rcpBlk/Communication/TCPsocketTxBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 # def TCPsocketTxRxBlk(pin, pout, IP, port):
 def TCPsocketTxRxBlk(*args):

--- a/resources/blocks/rcpBlk/Communication/UDPsocketRxBlk.py
+++ b/resources/blocks/rcpBlk/Communication/UDPsocketRxBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def UDPsocketRxBlk(pout, IP, port):
     """

--- a/resources/blocks/rcpBlk/Communication/UDPsocketTxBlk.py
+++ b/resources/blocks/rcpBlk/Communication/UDPsocketTxBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def UDPsocketTxBlk(pin, IP, port):
     """

--- a/resources/blocks/rcpBlk/Communication/serialInBlk.py
+++ b/resources/blocks/rcpBlk/Communication/serialInBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def serialInBlk(pout, port):
     """

--- a/resources/blocks/rcpBlk/Communication/serialInFloatBlk.py
+++ b/resources/blocks/rcpBlk/Communication/serialInFloatBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def serialInFloatBlk(pout, port):
     """

--- a/resources/blocks/rcpBlk/Communication/unixsocketCBlk.py
+++ b/resources/blocks/rcpBlk/Communication/unixsocketCBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def unixsocketCBlk(pin, sockname):
     """

--- a/resources/blocks/rcpBlk/Communication/unixsocketSBlk.py
+++ b/resources/blocks/rcpBlk/Communication/unixsocketSBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size, zeros
+from numpy import size, zeros
 
 def unixsocketSBlk(pout, sockname, defvals):
     """

--- a/resources/blocks/rcpBlk/Math/clarke_forwardBlk.py
+++ b/resources/blocks/rcpBlk/Math/clarke_forwardBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def clarke_forwardBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/Math/clarke_inverseBlk.py
+++ b/resources/blocks/rcpBlk/Math/clarke_inverseBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def clarke_inverseBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/Math/divBlk.py
+++ b/resources/blocks/rcpBlk/Math/divBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def divBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/Math/park_forwardBlk.py
+++ b/resources/blocks/rcpBlk/Math/park_forwardBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def park_forwardBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/Math/park_inverseBlk.py
+++ b/resources/blocks/rcpBlk/Math/park_inverseBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def park_inverseBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/Math/prodBlk.py
+++ b/resources/blocks/rcpBlk/Math/prodBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def prodBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/Math/relBlk.py
+++ b/resources/blocks/rcpBlk/Math/relBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def relBlk(pin, pout, operator):
     """

--- a/resources/blocks/rcpBlk/Math/sumBlk.py
+++ b/resources/blocks/rcpBlk/Math/sumBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def sumBlk(pin, pout, Gains):
     """

--- a/resources/blocks/rcpBlk/NuttX/microrosBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/microrosBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def microrosBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttxDIBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttxDIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttxDIBlk(pout, port):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttxDOBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttxDOBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttxDOBlk(pin, port, th):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttxENCBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttxENCBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttxENCBlk(pout, port, res, reset):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttxSerialOutBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttxSerialOutBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttxSerialOutBlk(pin, port, decim):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttx_ADCBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_ADCBlk.py
@@ -1,6 +1,6 @@
 import numpy as np
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttx_ADCBlk(pout, devname, ch, res, umin, umax):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttx_DACBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_DACBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttx_DACBlk(pin, port, channel):
     """

--- a/resources/blocks/rcpBlk/NuttX/nuttx_PWMBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_PWMBlk.py
@@ -1,6 +1,6 @@
 import numpy as np
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttx_PWMBlk(pin, port, ch, freq, umin, umax):
     """

--- a/resources/blocks/rcpBlk/NuttX_sensors/nuttx_DHTXXBlk.py
+++ b/resources/blocks/rcpBlk/NuttX_sensors/nuttx_DHTXXBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nuttx_DHTXXBlk(pout, port):
     """

--- a/resources/blocks/rcpBlk/Raspberry/compFiltBlk.py
+++ b/resources/blocks/rcpBlk/Raspberry/compFiltBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def compFiltBlk(pin, pout, alfa):
     """

--- a/resources/blocks/rcpBlk/Raspberry/pi_ADBlk.py
+++ b/resources/blocks/rcpBlk/Raspberry/pi_ADBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def pi_ADBlk(pout, dev, ch, vref):
     """

--- a/resources/blocks/rcpBlk/Raspberry/pwmBlk.py
+++ b/resources/blocks/rcpBlk/Raspberry/pwmBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def pwmBlk(pin, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/SAMD21/ImuAccBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/ImuAccBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ImuAccBlk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/ImuGyroBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/ImuGyroBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ImuGyroBlk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/ImuTempBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/ImuTempBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def ImuTempBlk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiAIBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiAIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiAIBlk(pout, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiAOBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiAOBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiAOBlk(pin, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiDCMotBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiDCMotBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiDCMotBlk(pin, enCh, in1Ch, in2Ch):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiDIBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiDIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiDIBlk(pout, ch):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiDOBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiDOBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiDOBlk(pin, ch, thr):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiESCBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiESCBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiESCBlk(pin, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiEchoBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiEchoBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiEchoBlk(pout, trg, echo):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiLuxBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiLuxBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiLuxBlk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiPWMBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiPWMBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiPWMBlk(pin, ch, umin, umax, freq):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiRGBBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiRGBBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiRGBBlk(pin):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiRangeBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiRangeBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiRangeBlk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiSerialInBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiSerialInBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiSerialInBlk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/brikiSerialOutBlk.py
+++ b/resources/blocks/rcpBlk/SAMD21/brikiSerialOutBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def brikiSerialOutBlk(pin, decim):
     """

--- a/resources/blocks/rcpBlk/SAMD21/fromESP32Blk.py
+++ b/resources/blocks/rcpBlk/SAMD21/fromESP32Blk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def fromESP32Blk(pout):
     """

--- a/resources/blocks/rcpBlk/SAMD21/toESP32Blk.py
+++ b/resources/blocks/rcpBlk/SAMD21/toESP32Blk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def toESP32Blk(pin):
     """

--- a/resources/blocks/rcpBlk/STM32H7/USB_OTG_OutBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/USB_OTG_OutBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def USB_OTG_OutBlk(pin, decim):
     """

--- a/resources/blocks/rcpBlk/STM32H7/stm32AIBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32AIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stm32AIBlk(pout, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/STM32H7/stm32AOBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32AOBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stm32AOBlk(pin, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/STM32H7/stm32DCMotBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32DCMotBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stm32DCMotBlk(pin, pwmCh, dir1Port, dir1Ch, dir2Port, dir2Ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/STM32H7/stm32DIBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32DIBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stm32DIBlk(pout, port, ch):
     """

--- a/resources/blocks/rcpBlk/STM32H7/stm32DOBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32DOBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stm32DOBlk(pin, port, ch, Th):
     """

--- a/resources/blocks/rcpBlk/STM32H7/stm32ENCBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32ENCBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 import numpy as np
 
 def stm32ENCBlk(pout, res):

--- a/resources/blocks/rcpBlk/STM32H7/stm32PWMBlk.py
+++ b/resources/blocks/rcpBlk/STM32H7/stm32PWMBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stm32PWMBlk(pin, ch, umin, umax):
     """

--- a/resources/blocks/rcpBlk/arduinoFirmata/analogWrite_af.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/analogWrite_af.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def analogWrite_af(pin, devicePin,pinMode):
     """

--- a/resources/blocks/rcpBlk/arduinoFirmata/customRead_af.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/customRead_af.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 
 def customRead_af(pout, value):

--- a/resources/blocks/rcpBlk/arduinoFirmata/digitalWrite_af.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/digitalWrite_af.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def digitalWrite_af(pin, devicePin):
     """

--- a/resources/blocks/rcpBlk/arduinoFirmata/encoderRead_af.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/encoderRead_af.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def encoderRead_af(pout, encno, pinA, pinB):
     """

--- a/resources/blocks/rcpBlk/arduinoFirmata/help_HeatShield_temperature.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/help_HeatShield_temperature.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def help_HeatShield_temperature(pin, pout, ADCREF, AREF, REF_TEMP, NTC_RES, VD_RES, VD_REF, NTC_BETA, ABSZERO):
     """

--- a/resources/blocks/rcpBlk/arduinoFirmata/help_TCLab_temperature.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/help_TCLab_temperature.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 
 def help_TCLab_temperature(pin, pout):

--- a/resources/blocks/rcpBlk/arduinoFirmata/pinRead_af.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/pinRead_af.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def pinRead_af(pout, devicepin, pinmode):
     """

--- a/resources/blocks/rcpBlk/arduinoFirmata/setup_af.py
+++ b/resources/blocks/rcpBlk/arduinoFirmata/setup_af.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 
 def setup_af(port, baud):

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_ADBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_ADBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_3XXX_ADBlk(pout, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_ENCBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_ENCBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_3XXX_ENCBlk(pout, candev, ID, res):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_INIT_Blk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_INIT_Blk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_3XXX_INIT_Blk(candev, id, Kp_pos, Kd_pos, Kp_v, Ki_v, encres):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_VBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_VBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_3XXX_VBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_XBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_XBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_3XXX_XBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_getVBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_3XXX_getVBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_3XXX_getVBlk(pout, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_CO_MotXBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_3XXX/FH_CO_MotXBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_CO_MotXBlk(pin, candev, ID, res):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_ADBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_ADBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_ADBlk(pout, candev, ID, ch):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_ENCBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_ENCBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_ENCBlk(pout, candev, ID, res):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_INIT_Blk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_INIT_Blk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_INIT_Blk(candev, id, Kp_pos, Kd_pos, Kp_v, Ki_v, Kp_tq, Ki_tq, encres):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_VBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_VBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_VBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_XBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_XBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_XBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_getTQBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_getTQBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_getTQBlk(pout, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_getVBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_getVBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_getVBlk(pout, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_setTQBlk.py
+++ b/resources/blocks/rcpBlk/can_Faulhaber_5XXX/FH_5XXX_setTQBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def FH_5XXX_setTQBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/epos_EncBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/epos_EncBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def epos_EncBlk(pout, candev, ID, res):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/epos_MotIBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/epos_MotIBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def epos_MotIBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/epos_MotXBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/epos_MotXBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def epos_MotXBlk(pin, candev, ID):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/epos_areadBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/epos_areadBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def epos_areadBlk(pout, candev, ID, ch):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/init_epos_MotIBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/init_epos_MotIBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def init_epos_MotIBlk(candev, ID, propGain, intGain, mode):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/maxon_EncBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/maxon_EncBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def maxon_EncBlk(pout, candev, ID, res):
     """

--- a/resources/blocks/rcpBlk/can_Maxon/maxon_MotBlk.py
+++ b/resources/blocks/rcpBlk/can_Maxon/maxon_MotBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def maxon_MotBlk(pin, candev, ID, propGain, intGain):
     """

--- a/resources/blocks/rcpBlk/can_generic/baumer_EncBlk.py
+++ b/resources/blocks/rcpBlk/can_generic/baumer_EncBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def baumer_EncBlk(pout, candev, ID, res, encres):
     """

--- a/resources/blocks/rcpBlk/can_generic/can_gen_recvBlk.py
+++ b/resources/blocks/rcpBlk/can_generic/can_gen_recvBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def can_gen_recvBlk(pout, candev, ID, retID, index, subindex, K):
     """

--- a/resources/blocks/rcpBlk/can_generic/can_sdo_recvBlk.py
+++ b/resources/blocks/rcpBlk/can_generic/can_sdo_recvBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def can_sdo_recvBlk(pout, candev, ID, index, subindex, K):
     """

--- a/resources/blocks/rcpBlk/can_generic/can_sdo_sendThBlk.py
+++ b/resources/blocks/rcpBlk/can_generic/can_sdo_sendThBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def can_sdo_sendThBlk(pin, candev, ID, index, subindex, data, useInp):
     """

--- a/resources/blocks/rcpBlk/comedi/comediADBlk.py
+++ b/resources/blocks/rcpBlk/comedi/comediADBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def comediADBlk(pout, dev, ch, cr, ref):
     """

--- a/resources/blocks/rcpBlk/comedi/comediDABlk.py
+++ b/resources/blocks/rcpBlk/comedi/comediDABlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def comediDABlk(pin, dev, ch, cr,ref):
     """

--- a/resources/blocks/rcpBlk/comedi/comediDIBlk.py
+++ b/resources/blocks/rcpBlk/comedi/comediDIBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def comediDIBlk(pout, dev, ch):
     """

--- a/resources/blocks/rcpBlk/comedi/comediDOBlk.py
+++ b/resources/blocks/rcpBlk/comedi/comediDOBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def comediDOBlk(pin, dev, ch, thr):
     """

--- a/resources/blocks/rcpBlk/comedi/comediENCBlk.py
+++ b/resources/blocks/rcpBlk/comedi/comediENCBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def comediENCBlk(pout, dev, ch):
     """

--- a/resources/blocks/rcpBlk/comedi/comediPWMBlk.py
+++ b/resources/blocks/rcpBlk/comedi/comediPWMBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def comediPWMBlk(pin, devicename, channel, prescaler, pfiout):
     """Create Comedi_PWM block 

--- a/resources/blocks/rcpBlk/input/constBlk.py
+++ b/resources/blocks/rcpBlk/input/constBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def constBlk(pout, val):
     """

--- a/resources/blocks/rcpBlk/input/extdataBlk.py
+++ b/resources/blocks/rcpBlk/input/extdataBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def extdataBlk(pout, ch, datasize, fname):
     """

--- a/resources/blocks/rcpBlk/input/getTimerBlk.py
+++ b/resources/blocks/rcpBlk/input/getTimerBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def getTimerBlk(pout):
     """

--- a/resources/blocks/rcpBlk/input/sineBlk.py
+++ b/resources/blocks/rcpBlk/input/sineBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def sineBlk(pout, Amp, Freq, Phase, Bias, Delay):
     """

--- a/resources/blocks/rcpBlk/input/squareBlk.py
+++ b/resources/blocks/rcpBlk/input/squareBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def squareBlk(pout, Amp, Period, Width, Bias, Delay):
     """

--- a/resources/blocks/rcpBlk/input/stepBlk.py
+++ b/resources/blocks/rcpBlk/input/stepBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def stepBlk(pout, initTime, iVal, fVal):
     """

--- a/resources/blocks/rcpBlk/linear/cssBlk.py
+++ b/resources/blocks/rcpBlk/linear/cssBlk.py
@@ -1,7 +1,6 @@
 from supsisim.RCPblk import RCPblk
 from control import tf2ss, TransferFunction
-from scipy import mat, shape, size, zeros
-from numpy import reshape, hstack
+from numpy import reshape, hstack, mat, shape, size, zeros
 
 def cssBlk(pin,pout,sys,X0=[]):
     """ 

--- a/resources/blocks/rcpBlk/linear/discretePIDBlk.py
+++ b/resources/blocks/rcpBlk/linear/discretePIDBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def discretePIDBlk(pin, pout, Kp, Ki, Kd, min_val, max_val):
     """

--- a/resources/blocks/rcpBlk/linear/dssBlk.py
+++ b/resources/blocks/rcpBlk/linear/dssBlk.py
@@ -1,7 +1,6 @@
 from supsisim.RCPblk import RCPblk
 from control import tf2ss, TransferFunction
-from scipy import mat, shape, size, zeros
-from numpy import reshape, hstack
+from numpy import reshape, hstack, mat, shape, size, zeros
 
 def dssBlk(pin,pout,sys,X0=[]):
     """

--- a/resources/blocks/rcpBlk/linear/init_encBlk.py
+++ b/resources/blocks/rcpBlk/linear/init_encBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def init_encBlk(pin, pout, trgtime, defv, offset):
     """

--- a/resources/blocks/rcpBlk/linear/intgBlk.py
+++ b/resources/blocks/rcpBlk/linear/intgBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def intgBlk(pin,pout,X0=0.0):
     """ 

--- a/resources/blocks/rcpBlk/linear/matmultBlk.py
+++ b/resources/blocks/rcpBlk/linear/matmultBlk.py
@@ -1,7 +1,6 @@
 from supsisim.RCPblk import RCPblk
 from control import tf2ss, TransferFunction
-from scipy import shape, size, mat
-from numpy import reshape
+from numpy import reshape, shape, size, mat
 
 def matmultBlk(pin, pout, Gains):
     """

--- a/resources/blocks/rcpBlk/linear/zdelayBlk.py
+++ b/resources/blocks/rcpBlk/linear/zdelayBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def zdelayBlk(pin, pout, X0=0.0):
     """

--- a/resources/blocks/rcpBlk/linux_mz_apo/mz_apo_DCmotBlk.py
+++ b/resources/blocks/rcpBlk/linux_mz_apo/mz_apo_DCmotBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def mz_apo_DCmotBlk(pin, pout, mot_ID):
     """

--- a/resources/blocks/rcpBlk/linux_mz_apo/mz_apo_ENCBlk.py
+++ b/resources/blocks/rcpBlk/linux_mz_apo/mz_apo_ENCBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def mz_apo_ENCBlk(pout, channel, init_val):
     """

--- a/resources/blocks/rcpBlk/nonlin/absBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/absBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def absBlk(pin, pout):
     """

--- a/resources/blocks/rcpBlk/nonlin/deadzoneBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/deadzoneBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def deadzoneBlk(pin, pout, start, end):
     """

--- a/resources/blocks/rcpBlk/nonlin/genericBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/genericBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def genericBlk(pin, pout, nx, uy, rP, iP, strP, fname):
     """

--- a/resources/blocks/rcpBlk/nonlin/lutBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/lutBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def lutBlk(pin, pout, coeff):
     """

--- a/resources/blocks/rcpBlk/nonlin/saturBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/saturBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def saturBlk(pin, pout, satP, satN):
     """

--- a/resources/blocks/rcpBlk/nonlin/switchBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/switchBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def switchBlk(pin, pout, cond, val, pers):
     """

--- a/resources/blocks/rcpBlk/nonlin/switchOutBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/switchOutBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def switchOutBlk(pin, pout, val):
     """

--- a/resources/blocks/rcpBlk/nonlin/trigBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/trigBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def trigBlk(pin, pout, tp):
     """

--- a/resources/blocks/rcpBlk/nonlin/upowBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/upowBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def upowBlk(pin, pout, K, exp):
     """

--- a/resources/blocks/rcpBlk/output/loggerBlk.py
+++ b/resources/blocks/rcpBlk/output/loggerBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def loggerBlk(pin, log_file):
     """Wrtie pin to log_file."""

--- a/resources/blocks/rcpBlk/output/nullBlk.py
+++ b/resources/blocks/rcpBlk/output/nullBlk.py
@@ -1,6 +1,6 @@
 
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def nullBlk(pin):
     """

--- a/resources/blocks/rcpBlk/output/plotBlk.py
+++ b/resources/blocks/rcpBlk/output/plotBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def plotBlk(pin, fname):
     """

--- a/resources/blocks/rcpBlk/output/printBlk.py
+++ b/resources/blocks/rcpBlk/output/printBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def printBlk(pin):
     """

--- a/resources/blocks/rcpBlk/output/scopeStream.py
+++ b/resources/blocks/rcpBlk/output/scopeStream.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def scopeStream(pin, timed=1, decim=1):
     """Create an interactive scope."""

--- a/resources/blocks/rcpBlk/output/toFileBlk.py
+++ b/resources/blocks/rcpBlk/output/toFileBlk.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 def toFileBlk(pin, fname):
     """

--- a/resources/blocks/rcpBlk/tos1a/tos1a.py
+++ b/resources/blocks/rcpBlk/tos1a/tos1a.py
@@ -1,5 +1,5 @@
 from supsisim.RCPblk import RCPblk
-from scipy import size
+from numpy import size
 
 
 def tos1a(pin, pout, port, lamp, vent, temp):

--- a/toolbox/supsisim/supsisim/RCPgen.py
+++ b/toolbox/supsisim/supsisim/RCPgen.py
@@ -15,8 +15,7 @@ The following commands are provided:
   sch2blks       - Generate block list fron schematic
   
 """
-from scipy import mat, size, array, zeros
-from numpy import  nonzero, ones
+from numpy import  nonzero, ones, mat, size, array, zeros
 from os import environ
 import copy
 import sys

--- a/toolbox/supsisim/supsisim/SHVgen.py
+++ b/toolbox/supsisim/supsisim/SHVgen.py
@@ -11,7 +11,7 @@ The following commands are provided:
   genSHVend      - Provide call for tree destruction
 """
 
-from scipy import size
+from numpy import size
 from os import environ
 import copy
 


### PR DESCRIPTION
I'm facing problems with code generation when running scipy >= 1.12.0 because of probably deprecated functions which are however part of numpy. I propose replacing such scipy imports with numpy ones. 