### PR TITLE
CodeGen/nuttx/devices/nuttx_PWM.c: init channels with PWM_DCPOL_LOW

### DIFF
--- a/CodeGen/nuttx/devices/nuttx_PWM.c
+++ b/CodeGen/nuttx/devices/nuttx_PWM.c
@@ -144,8 +144,9 @@ static void inout(python_block *block)
     {
       info.channels[i].channel = 0;
       info.channels[i].duty = 0;
-    #ifdef PWM_CPOL_HIGH
+    #if defined(PWM_CPOL_HIGH) && defined(PWM_DCPOL_LOW)
       info.channels[i].cpol = PWM_CPOL_HIGH;
+      info.channels[i].dcpol = PWM_DCPOL_LOW;
     #endif
     }
 


### PR DESCRIPTION
By this time, the dcpol attribute has been accepted into the NuttX mainline. This way, the default state of the PWM channel in the disabled state is the logical zero.

TODO: make this configurable in the GUI.