### PR TITLE
CodeGen/nuttx: optional ROMFS content can be mounted into /etc on target

### DIFF
--- a/CodeGen/templates/nuttx.tmf
+++ b/CodeGen/templates/nuttx.tmf
@@ -1,6 +1,9 @@
 MODEL = $$MODEL$$
 all:  ../$(MODEL).elf ../$(MODEL)
 
+# Enable or define during make invocation to embed content of the specified
+# directory into ROM filesystem mounted into /etc on the target
+#EMBEDROMFS = romfs
 
 PYCODEGEN = $(PYSUPSICTRL)/CodeGen
 MAINDIR = $(PYCODEGEN)/src
@@ -37,6 +40,9 @@ NUTTX_INCLUDES = -isystem $(NUTTX_EXPORT)/include
 
 ifneq ($(filter -Wl%, $(NXFLATLDFLAGS1)$(NXFLATLDFLAGS2)),)
 GCC_LD_OPTION = -Wl,
+LD_RAW ?= $(CROSSDEV)ld
+else
+LD_RAW ?= $(LD)
 endif
 
 ifeq ($(LDSTARTGROUP),)
@@ -72,6 +78,41 @@ ELF_FILE_LDSCRIPT ?= $(wildcard $(NUTTX_EXPORT)/scripts/gnu-elf.ld)
 
 MAIN = nuttx_main
 ADD_FILES = $$ADD_FILES$$
+
+ifneq ($(EMBEDROMFS),)
+ifeq ($(shell grep CONFIG_ETC_ROMFSMOUNTPT $(NUTTX_EXPORT)/include/nuttx/config.h),)
+$(error CONFIG_ETC_ROMFS and CONFIG_ETC_ROMFSMOUNTPT are required for EMBEDROMFS)
+endif
+ifeq ($(wildcard $(abspath $(EMBEDROMFS))),)
+EMBEDROMFS_ABS=$(abspath ../$(EMBEDROMFS))
+ifeq ($(wildcard $(EMBEDROMFS_ABS)),)
+$(error Specified EMBEDROMFS=$(EMBEDROMFS) is not found)
+endif
+else
+EMBEDROMFS_ABS=$(abspath $(EMBEDROMFS))
+endif
+romfs_img_len_encode.c: Makefile
+	echo >$@ \
+	"#include <stdint.h>\n\
+	extern uint8_t romfs_img_size[];\
+	const unsigned int romfs_img_len = (uintptr_t)romfs_img_size;"
+romfs_img: $(shell find "$(EMBEDROMFS_ABS)" -type f,d) Makefile
+	rm -f $@.tmp
+	genromfs -f romfs_img.tmp -V romfs -d $<
+	if ( [ ! -e $@ ] || ! cmp -s $@.tmp $@ ) ; then cp $@.tmp $@ ; fi
+romfs_img.o: romfs_img
+	rm -f romfs_img.o.tmp
+	$(LD_RAW) -r --accept-unknown-input-arch -b binary \
+	$(filter -m%,$(LDFLAGS:$(GCC_LD_OPTION)%=%)) \
+	--defsym=romfs_img_size=_binary_romfs_img_size \
+	--defsym=romfs_img=_binary_romfs_img_start \
+	--defsym=romfs_img_start=_binary_romfs_img_start \
+	--defsym=romfs_img_end=_binary_romfs_img_end \
+	-o $@.tmp $<
+	$(OBJCOPY) --rename-section .data=.rodata,alloc,load,readonly,data,contents \
+	$@.tmp $@
+ADD_FILES += romfs_img.o romfs_img_len_encode.o
+endif
 
 OBJSSTAN = $(MAIN).o $(MODEL).o $(ADD_FILES)
 


### PR DESCRIPTION
EMBEDROMFS NuttX Makefile template option allows to embedded directory content into target application image in ROMFS. The content is mounted to /etc in the running NuttX system.

The content of the init.d/rcS file is executed by NSH at startup. It can be used to setup system or even load FPGA bitstream from other file stored under /etc, for example. The start of the pysimCoder model even with parameters is possible as the last action as well. It can be run even in background if "main &" is specified.