### PR TITLE
Common: struct sockaddr_in is defined in netinet/in.h by standard

### DIFF
--- a/CodeGen/Common/posix/TCPsocketAsync.c
+++ b/CodeGen/Common/posix/TCPsocketAsync.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <math.h>

--- a/CodeGen/Common/posix/TCPsocketTxRx.c
+++ b/CodeGen/Common/posix/TCPsocketTxRx.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <math.h>

--- a/CodeGen/Common/posix/UDPsocketRx.c
+++ b/CodeGen/Common/posix/UDPsocketRx.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 static void * getData(void * p)

--- a/CodeGen/Common/posix/UDPsocketTx.c
+++ b/CodeGen/Common/posix/UDPsocketTx.c
@@ -21,6 +21,7 @@
 #include<unistd.h>
 #include<stdlib.h> 
 #include<arpa/inet.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include<sys/socket.h>
 #include <math.h>

--- a/CodeGen/Common/posix/plotJuggler.c
+++ b/CodeGen/Common/posix/plotJuggler.c
@@ -21,6 +21,7 @@
 #include<unistd.h>
 #include<stdlib.h> 
 #include<arpa/inet.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include<sys/socket.h>
 #include <string.h>

--- a/CodeGen/Common/shv/shv_com.c
+++ b/CodeGen/Common/shv/shv_com.c
@@ -23,6 +23,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <poll.h>
 #include <unistd.h>
 #include <stdio.h>


### PR DESCRIPTION
Without this header size of the structure is unknown on original BSD TCP/IP stack and code does not build for RTEMS which uses it.