### PR TITLE
CodeGen/nuttx/devices/nuttx_PWM.c: set CPOL and DCPOL in CG_INIT, too

### DIFF
--- a/CodeGen/nuttx/devices/nuttx_PWM.c
+++ b/CodeGen/nuttx/devices/nuttx_PWM.c
@@ -69,6 +69,10 @@ static void init(python_block *block)
     {
       info.channels[i].channel = 0;
       info.channels[i].duty = 0;
+    #if defined(PWM_CPOL_HIGH) && defined(PWM_DCPOL_LOW)
+      info.channels[i].cpol = PWM_CPOL_HIGH;
+      info.channels[i].dcpol = PWM_DCPOL_LOW;
+    #endif
     }
 
   /* Add channel numbr to first block->nin used channels */


### PR DESCRIPTION
These attributes should be set in the INIT phase too. It takes some time to init all the blocks and it may happen that during the INIT phase, an undefined channel polarity can cause trouble.