### PR TITLE
shv: add support for native double format

### DIFF
--- a/CodeGen/Common/shv/shv_com.c
+++ b/CodeGen/Common/shv/shv_com.c
@@ -596,7 +596,11 @@ int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d)
                     {
                       if (d) *d = (ctx->item.as.Decimal.mantisa * pow(10, ctx->item.as.Decimal.exponent));
                     }
-	              }
+                  else if (ctx->item.type == CCPCP_ITEM_DOUBLE)
+                    {
+                      if (d) *d = ctx->item.as.Double;
+                    }
+                }
             }
         }
     } while (ctx->err_no == CCPCP_RC_OK);


### PR DESCRIPTION
SHV can pack double values either as decimal (mantisa and exponent) or as native double (8 bytes, little endian). This adds the latter option to unpack function.

This enables other SHV tools like pySHV to send double directly without calculating mantisa and exponent.