### PR TITLE
BlockEditor/qtgRTScope.py: add support for pyqtgraph legends

### DIFF
--- a/BlockEditor/pyplt.ui
+++ b/BlockEditor/pyplt.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>675</width>
-    <height>369</height>
+    <height>368</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,9 +22,9 @@
   <widget class="QLabel" name="label_2">
    <property name="geometry">
     <rect>
-     <x>0</x>
+     <x>20</x>
      <y>170</y>
-     <width>111</width>
+     <width>50</width>
      <height>16</height>
     </rect>
    </property>
@@ -38,9 +38,9 @@
   <widget class="QLabel" name="label_3">
    <property name="geometry">
     <rect>
-     <x>0</x>
+     <x>20</x>
      <y>210</y>
-     <width>111</width>
+     <width>50</width>
      <height>16</height>
     </rect>
    </property>
@@ -54,9 +54,9 @@
   <widget class="QLabel" name="label_4">
    <property name="geometry">
     <rect>
-     <x>350</x>
-     <y>210</y>
-     <width>111</width>
+     <x>450</x>
+     <y>200</y>
+     <width>80</width>
      <height>16</height>
     </rect>
    </property>
@@ -70,7 +70,7 @@
   <widget class="QSpinBox" name="sbNsig">
    <property name="geometry">
     <rect>
-     <x>130</x>
+     <x>100</x>
      <y>160</y>
      <width>101</width>
      <height>31</height>
@@ -86,7 +86,7 @@
   <widget class="QLineEdit" name="edHist">
    <property name="geometry">
     <rect>
-     <x>130</x>
+     <x>100</x>
      <y>200</y>
      <width>101</width>
      <height>31</height>
@@ -102,8 +102,8 @@
   <widget class="QSpinBox" name="sbRefT">
    <property name="geometry">
     <rect>
-     <x>490</x>
-     <y>200</y>
+     <x>540</x>
+     <y>190</y>
      <width>91</width>
      <height>31</height>
     </rect>
@@ -127,8 +127,8 @@
   <widget class="QCheckBox" name="ckAutoscale">
    <property name="geometry">
     <rect>
-     <x>80</x>
-     <y>280</y>
+     <x>20</x>
+     <y>250</y>
      <width>85</width>
      <height>21</height>
     </rect>
@@ -146,8 +146,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>200</x>
-     <y>310</y>
+     <x>20</x>
+     <y>325</y>
      <width>57</width>
      <height>15</height>
     </rect>
@@ -162,8 +162,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>200</x>
-     <y>270</y>
+     <x>20</x>
+     <y>290</y>
      <width>57</width>
      <height>15</height>
     </rect>
@@ -178,8 +178,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>290</x>
-     <y>300</y>
+     <x>100</x>
+     <y>320</y>
      <width>81</width>
      <height>31</height>
     </rect>
@@ -197,8 +197,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>290</x>
-     <y>260</y>
+     <x>100</x>
+     <y>290</y>
      <width>81</width>
      <height>31</height>
     </rect>
@@ -600,8 +600,8 @@
   <widget class="QCheckBox" name="ckSaveData">
    <property name="geometry">
     <rect>
-     <x>460</x>
-     <y>260</y>
+     <x>450</x>
+     <y>240</y>
      <width>90</width>
      <height>23</height>
     </rect>
@@ -613,8 +613,8 @@
   <widget class="QLabel" name="label_8">
    <property name="geometry">
     <rect>
-     <x>390</x>
-     <y>290</y>
+     <x>450</x>
+     <y>270</y>
      <width>62</width>
      <height>21</height>
     </rect>
@@ -626,8 +626,8 @@
   <widget class="QLineEdit" name="lnFilename">
    <property name="geometry">
     <rect>
-     <x>460</x>
-     <y>290</y>
+     <x>450</x>
+     <y>300</y>
      <width>191</width>
      <height>25</height>
     </rect>
@@ -639,8 +639,8 @@
   <widget class="QCheckBox" name="ckTimeEnabled">
    <property name="geometry">
     <rect>
-     <x>380</x>
-     <y>170</y>
+     <x>450</x>
+     <y>160</y>
      <width>181</width>
      <height>24</height>
     </rect>
@@ -651,6 +651,26 @@
    <property name="checked">
     <bool>true</bool>
    </property>
+  </widget>
+  <widget class="QTableWidget" name="tableSig">
+   <property name="geometry">
+    <rect>
+     <x>240</x>
+     <y>160</y>
+     <width>170</width>
+     <height>170</height>
+    </rect>
+   </property>
+   <row>
+    <property name="text">
+     <string>1</string>
+    </property>
+   </row>
+   <column>
+    <property name="text">
+     <string>Signal names</string>
+    </property>
+   </column>
   </widget>
  </widget>
  <resources/>

--- a/BlockEditor/qtgRTScope.py
+++ b/BlockEditor/qtgRTScope.py
@@ -186,6 +186,12 @@ class MainWindow(QMainWindow, form_class):
         self.ckSaveData.stateChanged.connect(self.setSaveData)
         self.edYmax.editingFinished.connect(self.YAxes)
         self.edYmin.editingFinished.connect(self.YAxes)
+        self.sbNsig.valueChanged.connect(self.sbNsigValue)
+        self.tableSig.setColumnWidth(0, 150)
+
+    def sbNsigValue(self):
+        self.tableSig.setRowCount(self.sbNsig.value())
+        self.tableSig.setColumnWidth(0, 150)
 
     def edHistEdited(self, val):
         self.Hist = int(val.__str__())
@@ -301,11 +307,17 @@ class MainWindow(QMainWindow, form_class):
             self.plotWidget = pg.plot(title="Scopes")            
             self.plotWidget.resize(PLOT_WINDOM_SIZE[0], PLOT_WINDOM_SIZE[1])
             self.plotWidget.showGrid(x=True, y=True)
+            self.plotWidget.addLegend()
             self.plots = []
             
             for n in range(self.NSig):
+                sigName = self.tableSig.item(n, 0)
+                if sigName is None:
+                    sigName = "Signal " + str(n)
+                else:
+                    sigName = sigName.text()
                 c = PLOT_LINE_COLORS[n % len(PLOT_LINE_COLORS)]
-                self.plots.append(self.plotWidget.plot(self.x, self.y[n], pen={'color':c, 'width' : PENWIDTH}))
+                self.plots.append(self.plotWidget.plot(self.x, self.y[n], pen={'color':c, 'width' : PENWIDTH}, name=sigName))
             
             self.timer = QTimer()
             self.timer.timeout.connect(self.pltRefresh)


### PR DESCRIPTION
Reconfigure pyplt.ui to add a QTableWidget to incorporate names for signals. The number of rows depends on the number of signals in the Signals spin box. If the nth signal is empty, the name "Signal n" is used instead.

Please, look at the new QTForm. If you don't like anything I'd be happy to fix it.