### PR TITLE
fix: connected() funciton crashing on newver versions of pyshv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyqtgraph>=0.11.0 # MIT
 lxml>=4.6.3 # BSD License
 tornado>=6.1 #  Apache Software License 2.0
 scikit-build>=0.15.0 # MIT
+pyshv>=0.6.1 #MIT

--- a/toolbox/supsisim/supsisim/client.py
+++ b/toolbox/supsisim/supsisim/client.py
@@ -50,7 +50,7 @@ async def _set_parameter_value(client: SimpleClient, mount_point:str, device_id:
         print(e)
 
 async def _is_connected(client: SimpleClient) -> bool:
-    return client.client.connected()
+    return client.client.connected
 
 
 class BrokerConnection:


### PR DESCRIPTION
# Hotfix parametr tuning crash

Pysimcoder no longer crashes with pyshv of latest version v0.6.1.

Pyshv v0.6.1 was also added to requirements.txt