### PR TITLE
toolbox/editor.py: use correct item idents in shvAction

### DIFF
--- a/toolbox/supsisim/supsisim/editor.py
+++ b/toolbox/supsisim/supsisim/editor.py
@@ -241,7 +241,10 @@ class Editor(QObject):
             dlg.setIcon(QMessageBox.Icon.Warning)
             dlg.exec()
             return
-    
+
+        # get corret name.ident values for the SHV paths to blocks
+        self.scene.findAllItems(self.scene)
+
         item = self.scene.item
         params = item.params.split('|')
         blk = params[0]


### PR DESCRIPTION
Item idents are calculated during code generation based on the connections between blocks. Newly introduced tuning over pySHV needs correct item idents even if the connection is made from a diagram without previous code generation. This fixes the issue when the diagram was reopened and tuning was not working.