### PR TITLE
CodeGen/nuttx/devices/nuttx_ADC.c: add a SW Trigger field to xblk

### DIFF
--- a/resources/blocks/blocks/NuttX/nuttx_ADC.xblk
+++ b/resources/blocks/blocks/NuttX/nuttx_ADC.xblk
@@ -6,6 +6,6 @@
   "stin": 0,
   "stout": 1,
   "icon": "AD",
-  "params": "nuttx_ADCBlk|Port:'/dev/adc0'|Channel: [0]|Resolution: 4095:double|Umin [V]:0.0:double|Umax [V]:3.3:double",
-  "help": "Parameters\nChannel: [0, 1,..]     Target depending\nPort : device name (ex. '/dev/adc0')\nResolution of ADC\nUmin [V]: minimal value (0 volt read -> umin)\nUmax [V] : maximal value (3.3V read -> umax)\n"
+  "params": "nuttx_ADCBlk|Port:'/dev/adc0'|Channel: [0]|SW Trigger needed: 0:int|Resolution: 4095:double|Umin [V]:0.0:double|Umax [V]:3.3:double",
+  "help": "Parameters\nChannel: [0, 1,..]     Target depending\nPort : device name (ex. '/dev/adc0')\nSW Trigger On/Off: 1/0 - some ADCs need to be SW triggered first to measure\nResolution of ADC\nUmin [V]: minimal value (0 volt read -> umin)\nUmax [V] : maximal value (3.3V read -> umax)\n"
 }

--- a/resources/blocks/rcpBlk/NuttX/nuttx_ADCBlk.py
+++ b/resources/blocks/rcpBlk/NuttX/nuttx_ADCBlk.py
@@ -2,7 +2,7 @@ import numpy as np
 from supsisim.RCPblk import RCPblk
 from numpy import size
 
-def nuttx_ADCBlk(pout, devname, ch, res, umin, umax):
+def nuttx_ADCBlk(pout, devname, ch, swtrig, res, umin, umax):
     """
 
     Call:   nuttx_AdcBlk(pout, devname)
@@ -12,6 +12,7 @@ def nuttx_ADCBlk(pout, devname, ch, res, umin, umax):
        pout: connected output port(s)
        devname : Port
        ch: array of ADC channels
+       swtrig: flag to either SW trigger or not
        res: resolution of the ADC
        umin: minimal value
        umax: maximum value
@@ -29,8 +30,9 @@ def nuttx_ADCBlk(pout, devname, ch, res, umin, umax):
         raise ValueError("ADC block: duplicate channels!")
 
     ch.append(res)
-    ch.append(0)  # file descriptor
-    ch.append(0)  # number of configured chanels get by ioctl command
+    ch.append(0)      # file descriptor
+    ch.append(0)      # number of configured chanels get by ioctl command
+    ch.append(swtrig) # boolean flag to SW trigger or not
 
     blk = RCPblk('nuttx_ADC', [], pout, [0,0], 0, [umin, umax], ch, devname)
     return blk


### PR DESCRIPTION
If this option is turned on, the device is opened in a BLOCKING way, otherwise not. Also, it triggers the ANIOC_TRIGGER ioctl call. This commit makes the code more readable as the ANIOC_TRIGGER is not defined by a CONFIG NuttX macro.