### PR TITLE
CodeGen/linux_mz_apo and RPi: correct initialization of PMSM state and define IRC position as signed

### DIFF
--- a/CodeGen/Raspberry_PI/devices/P3M_spi.c
+++ b/CodeGen/Raspberry_PI/devices/P3M_spi.c
@@ -61,7 +61,7 @@ static void init(python_block *block)
       fprintf(stderr, "malloc spimcst failed");
       return;
   }
-  memset(spimcst, sizeof(*spimcst), 0);
+  memset(spimcst, 0, sizeof(*spimcst));
 
   spimcst->spi_dev = "/dev/spidev0.1";
 
@@ -153,12 +153,10 @@ static void inout(python_block *block)
       }
   }
 
-  irc_pos[0] = (double)(spimcst->act_pos + spimcst->pos_offset);
-  irc_idx[0] = (double)(spimcst->index_pos + spimcst->pos_offset);
+  irc_pos[0] = (double)(int32_t)(spimcst->act_pos + spimcst->pos_offset);
+  irc_idx[0] = (double)(int32_t)(spimcst->index_pos + spimcst->pos_offset);
   irc_idx_occ[0] = (double)spimcst->index_occur;
   hal_sec[0] = (double)pxmc_lpc_bdc_hal_pos_table[spimcst->hal_sensors];
-
-
 }
 
 /*  TERMINATION FUNCTION  */

--- a/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1.c
+++ b/CodeGen/linux_mz_apo/devices/zynq_3pmdrv1.c
@@ -54,7 +54,7 @@ static void init(python_block *block)
       fprintf(stderr, "malloc mcst failed");
       return;
   }
-  memset(mcst, sizeof(*mcst), 0);
+  memset(mcst, 0, sizeof(*mcst));
 
   if (z3pmdrv1_init(mcst) < 0) {
       fprintf(stderr, "z3pmdrv1_init mcst failed");
@@ -172,12 +172,10 @@ static void inout(python_block *block)
   }
  #endif
 
-  irc_pos[0] = (double)(mcst->act_pos + mcst->pos_offset);
-  irc_idx[0] = (double)(mcst->index_pos + mcst->pos_offset);
+  irc_pos[0] = (double)(int32_t)(mcst->act_pos + mcst->pos_offset);
+  irc_idx[0] = (double)(int32_t)(mcst->index_pos + mcst->pos_offset);
   irc_idx_occ[0] = (double)mcst->index_occur;
   hal_sec[0] = (double)pxmc_lpc_bdc_hal_pos_table[mcst->hal_sensors];
-
-
 }
 
 /*  TERMINATION FUNCTION  */


### PR DESCRIPTION
The correction is based on previous problems findings on NuttX PMSM interface.