### PR TITLE
shv: add pyshv broker configuration

### DIFF
--- a/BlockEditor/broker_conf.toml
+++ b/BlockEditor/broker_conf.toml
@@ -1,0 +1,11 @@
+name = "pysimCoderBroker"
+listen = ["tcp://[::]:3755", "unix:shvbroker.sock"]
+
+[user.admin]
+password = "admin!123"
+role = "admin"
+
+[role.admin]
+access.ssrv = "**"
+mountPoints = "**" # can mount itself anywhere
+access.dev = "**:*" # can access everything with DEV level

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pyqtgraph>=0.11.0 # MIT
 lxml>=4.6.3 # BSD License
 tornado>=6.1 #  Apache Software License 2.0
 scikit-build>=0.15.0 # MIT
-pyshv>=0.6.1 #MIT
+pyshv>=0.7.2 #MIT


### PR DESCRIPTION
This adds simple configuration for running pyshv broker. It can be run by command:

`pyshvbroker -c BlockEditor/broker_conf.toml`

Python 3.11 has to be used for pyshv in version 0.7.2.