### PR TITLE
toolbox/supsisim/supsisim/shv/generator.py: wrong variable names

### DIFF
--- a/toolbox/supsisim/supsisim/shv/generator.py
+++ b/toolbox/supsisim/supsisim/shv/generator.py
@@ -96,10 +96,10 @@ class ShvTreeGenerator:
                     real_par_names = []
 
                     if size(self.blocks[index].realPar) == size(
-                        self.blocks[index].real_par_names
+                        self.blocks[index].realParNames
                     ):
                         for i in range(0, size(self.blocks[index].realPar)):
-                            real_par_names.append(self.blocks[index].real_par_names[i])
+                            real_par_names.append(self.blocks[index].realParNames[i])
                     else:
                         for i in range(0, size(self.blocks[index].realPar)):
                             real_par_names.append("double" + str(i))


### PR DESCRIPTION
RCPblk has no attribute real_par_names but rather realParNames.

Without this change, the code generation sometimes resulted in a runtime Python error.