### PR TITLE
Nuttx: more robust detectection that standalone ELF is supported and some more cleanups

### DIFF
--- a/CodeGen/nuttx/devices/Makefile
+++ b/CodeGen/nuttx/devices/Makefile
@@ -56,11 +56,13 @@ SRCALL += nuttxENC.c
 endif
 
 ifeq ($(CONFIG_SPI),y)
+ifeq ($(CONFIG_SPI_EXCHANGE),y)
 SRCALL += heater.c
 SRCALL += RLC.c
 SRCALL += DCMOT.c
 SRCALL += nuttx_p3m_spi.c
 SRCALL += pm_mc1_spi.c
+endif
 endif
 
 ifeq ($(CONFIG_SENSORS_DHTXX),y)

--- a/CodeGen/nuttx/devices/canopen.c
+++ b/CodeGen/nuttx/devices/canopen.c
@@ -166,6 +166,10 @@ void sendMsg(uint16_t ID, uint8_t DATA[], int len)
 {
   /* Procedure to send a CAN message */
 
+#ifdef CONFIG_CAN_EXTID
+  uint8_t extended = 0;
+#endif
+
 #ifdef CONFIG_NET_CAN
   struct can_frame txmsg;
 #else

--- a/CodeGen/templates/nuttx.tmf
+++ b/CodeGen/templates/nuttx.tmf
@@ -1,5 +1,7 @@
 MODEL = $$MODEL$$
-all:  ../$(MODEL).elf ../$(MODEL).bin ../$(MODEL)
+all: default
+
+.PHONY: all default
 
 # Enable or define during make invocation to embed content of the specified
 # directory into ROM filesystem mounted into /etc on the target
@@ -19,6 +21,8 @@ EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c/include
 RM = rm -f
 FILES_TO_CLEAN = *.o $(MODEL) $(MODEL).elf $(MAIN)-builtintab.c
 
+MODEL_BINARIES := ../$(MODEL).bin ../$(MODEL)
+
 ifndef NUTTX_EXPORT
 $(warning Specify NUTTX_EXPORT)
 $(warning make_rtw NUTTX_EXPORT=/path/to/nuttx-export)
@@ -29,9 +33,9 @@ ifneq ($(wildcard $(NUTTX_EXPORT)/registry/*.bdat),)
 NUTTX_REGISTER_BINARIES ?= y
 endif
 
-ifneq ($(shell grep CONFIG_INTELHEX_BINARY $(NUTTX_EXPORT)/include/nuttx/config.h),)
+ifneq ($(shell grep 'CONFIG_INTELHEX_BINARY[[:blank:]]*1' "$(NUTTX_EXPORT)/include/nuttx/config.h"),)
 CONFIG_INTELHEX_BINARY = 1
-all:  ../$(MODEL).hex
+MODEL_BINARIES += ../$(MODEL).hex
 endif
 
 include $(NUTTX_EXPORT)/scripts/Make.defs
@@ -74,13 +78,23 @@ LDFLAGS_LD_SCRIPTS += $(LD_SCRIPTS:%=-T %)
 
 LDFLAGS  += --entry=__start
 
+ifndef LDELFFLAGS
 ELF_FILE_LDSCRIPT ?= $(wildcard $(NUTTX_EXPORT)/scripts/gnu-elf.ld)
+ifneq ($(ELF_FILE_LDSCRIPT),)
+LDELFFLAGS = $(LDFLAGS) -r -e main -T "$(ELF_FILE_LDSCRIPT)"
+endif
+endif
+
+ifneq ($(shell grep 'CONFIG_ELF[[:blank:]]*1' "$(NUTTX_EXPORT)/include/nuttx/config.h"),)
+CONFIG_ELF_BINARY = 1
+MODEL_BINARIES := ../$(MODEL).elf $(MODEL_BINARIES)
+endif
 
 MAIN = nuttx_main
 ADD_FILES = $$ADD_FILES$$
 
 ifneq ($(EMBEDROMFS),)
-ifeq ($(shell grep CONFIG_ETC_ROMFSMOUNTPT $(NUTTX_EXPORT)/include/nuttx/config.h),)
+ifeq ($(shell grep CONFIG_ETC_ROMFSMOUNTPT "$(NUTTX_EXPORT)/include/nuttx/config.h"),)
 $(error CONFIG_ETC_ROMFS and CONFIG_ETC_ROMFSMOUNTPT are required for EMBEDROMFS)
 endif
 ifeq ($(wildcard $(abspath $(EMBEDROMFS))),)
@@ -156,6 +170,8 @@ CXXFLAGS = $(TARGET_ARCH_FLAGS) $(ARCHCXXFLAGS) $(ARCHWARNINGSXX) $(OPT_OPTS) $(
 
 LIB = $(LIBDIR)/libpyblk.a
 
+default: $(MODEL_BINARIES)
+
 $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	cp $< .
 
@@ -163,15 +179,16 @@ $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	$(CC) -c -o $@ $(CFLAGS) $<
 
 ../$(MODEL).elf: $(OBJSSTAN) $(LIB)
-	[ ! -e  $(ELF_FILE_LDSCRIPT) ] || \
-	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) -o $@ \
-	  -r -e main -T $(ELF_FILE_LDSCRIPT) \
+	[ -z "$(LDELFFLAGS)" ] || \
+	$(LD) -L $(NUTTX_EXPORT)/scripts $(LDELFFLAGS) \
+	  $(ADDITIONAL_LDFLAGS) -o $@ \
 	  $(GCC_LD_OPTION)-Map $(GCC_LD_OPTION)$(notdir $@).map \
 	  $(OBJSSTAN) $(LIB) $(LIBS) $(ELF_MODULE_LIBS)
 	@echo "### Created ELF loadable file: $(MODEL).elf"
 
 ../$(MODEL): $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB)
-	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) $(LDFLAGS_LD_SCRIPTS) \
+	$(LD) -L $(NUTTX_EXPORT)/scripts $(LDFLAGS) \
+	  $(ADDITIONAL_LDFLAGS) $(LDFLAGS_LD_SCRIPTS) \
 	  -o $@ $(HEAD_OBJ:%=$(NUTTX_EXPORT)/startup/%) \
 	  $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB) $(SYSTEM_LIBS)
 	@echo "### Created executable: $(MODEL)"

--- a/CodeGen/templates/nuttx_timehook.tmf
+++ b/CodeGen/templates/nuttx_timehook.tmf
@@ -1,5 +1,7 @@
 MODEL = $$MODEL$$
-all:  ../$(MODEL).elf ../$(MODEL).bin ../$(MODEL)
+all: default
+
+.PHONY: all default
 
 # Enable or define during make invocation to embed content of the specified
 # directory into ROM filesystem mounted into /etc on the target
@@ -19,6 +21,8 @@ EXT_SHV_INC = $(PYSUPSICTRL)/ExtLibs//libshv/libshvchainpack/c/include
 RM = rm -f
 FILES_TO_CLEAN = *.o $(MODEL) $(MODEL).elf $(MAIN)-builtintab.c
 
+MODEL_BINARIES := ../$(MODEL).bin ../$(MODEL)
+
 ifndef NUTTX_EXPORT
 $(warning Specify NUTTX_EXPORT)
 $(warning make_rtw NUTTX_EXPORT=/path/to/nuttx-export)
@@ -29,9 +33,9 @@ ifneq ($(wildcard $(NUTTX_EXPORT)/registry/*.bdat),)
 NUTTX_REGISTER_BINARIES ?= y
 endif
 
-ifneq ($(shell grep CONFIG_INTELHEX_BINARY $(NUTTX_EXPORT)/include/nuttx/config.h),)
+ifneq ($(shell grep 'CONFIG_INTELHEX_BINARY[[:blank:]]*1' "$(NUTTX_EXPORT)/include/nuttx/config.h"),)
 CONFIG_INTELHEX_BINARY = 1
-all:  ../$(MODEL).hex
+MODEL_BINARIES += ../$(MODEL).hex
 endif
 
 include $(NUTTX_EXPORT)/scripts/Make.defs
@@ -74,13 +78,23 @@ LDFLAGS_LD_SCRIPTS += $(LD_SCRIPTS:%=-T %)
 
 LDFLAGS  += --entry=__start
 
+ifndef LDELFFLAGS
 ELF_FILE_LDSCRIPT ?= $(wildcard $(NUTTX_EXPORT)/scripts/gnu-elf.ld)
+ifneq ($(ELF_FILE_LDSCRIPT),)
+LDELFFLAGS = $(LDFLAGS) -r -e main -T "$(ELF_FILE_LDSCRIPT)"
+endif
+endif
+
+ifneq ($(shell grep 'CONFIG_ELF[[:blank:]]*1' "$(NUTTX_EXPORT)/include/nuttx/config.h"),)
+CONFIG_ELF_BINARY = 1
+MODEL_BINARIES := ../$(MODEL).elf $(MODEL_BINARIES)
+endif
 
 MAIN = nuttx_main_timehook
 ADD_FILES = $$ADD_FILES$$
 
 ifneq ($(EMBEDROMFS),)
-ifeq ($(shell grep CONFIG_ETC_ROMFSMOUNTPT $(NUTTX_EXPORT)/include/nuttx/config.h),)
+ifeq ($(shell grep CONFIG_ETC_ROMFSMOUNTPT "$(NUTTX_EXPORT)/include/nuttx/config.h"),)
 $(error CONFIG_ETC_ROMFS and CONFIG_ETC_ROMFSMOUNTPT are required for EMBEDROMFS)
 endif
 ifeq ($(wildcard $(abspath $(EMBEDROMFS))),)
@@ -156,6 +170,8 @@ CXXFLAGS = $(TARGET_ARCH_FLAGS) $(ARCHCXXFLAGS) $(ARCHWARNINGSXX) $(OPT_OPTS) $(
 
 LIB = $(LIBDIR)/libpyblk.a
 
+default: $(MODEL_BINARIES)
+
 $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	cp $< .
 
@@ -163,15 +179,16 @@ $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 	$(CC) -c -o $@ $(CFLAGS) $<
 
 ../$(MODEL).elf: $(OBJSSTAN) $(LIB)
-	[ ! -e  $(ELF_FILE_LDSCRIPT) ] || \
-	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) -o $@ \
-	  -r -e main -T $(ELF_FILE_LDSCRIPT) \
+	[ -z "$(LDELFFLAGS)" ] || \
+	$(LD) -L $(NUTTX_EXPORT)/scripts $(LDELFFLAGS) \
+	  $(ADDITIONAL_LDFLAGS) -o $@ \
 	  $(GCC_LD_OPTION)-Map $(GCC_LD_OPTION)$(notdir $@).map \
 	  $(OBJSSTAN) $(LIB) $(LIBS) $(ELF_MODULE_LIBS)
 	@echo "### Created ELF loadable file: $(MODEL).elf"
 
 ../$(MODEL): $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB)
-	$(LD) $(LDFLAGS) $(ADDITIONAL_LDFLAGS) $(LDFLAGS_LD_SCRIPTS) \
+	$(LD) -L $(NUTTX_EXPORT)/scripts $(LDFLAGS) \
+	  $(ADDITIONAL_LDFLAGS) $(LDFLAGS_LD_SCRIPTS) \
 	  -o $@ $(HEAD_OBJ:%=$(NUTTX_EXPORT)/startup/%) \
 	  $(OBJSSTAN) $(OBJSSYSOVERRIDE) $(LIB) $(SYSTEM_LIBS)
 	@echo "### Created executable: $(MODEL)"
@@ -185,4 +202,3 @@ $(MAIN).c: $(MAINDIR)/$(MAIN).c $(MODEL).c
 
 clean:
 	@$(RM) $(FILES_TO_CLEAN)
-	

--- a/pysim-run.sh
+++ b/pysim-run.sh
@@ -5,21 +5,21 @@ export PYSUPSICTRL="$( cd "$(dirname "$0")" ; pwd )"
 if [ $# -eq 0 ]; then
     appname="pysimCoder"
 else
+    case "$1" in
+        -* ) appname="pysimCoder" ;;
+        *.dgm ) appname="pysimCoder" ;;
+        * ) appname="$(basename $1)" ; shift
+    esac
+fi
+
+if [ ! -e "$PYSUPSICTRL/BlockEditor/$appname.py" ] ; then
     # find all .py applications
-    applications=$(find $PYSUPSICTRL/BlockEditor -name "*.py" -execdir basename {} \; | sed s/.py//)
-    appname="$1"
-
-    # match whole words only
-    if ! echo $applications | grep -w "$appname" > /dev/null 2>&1 ; then
-        scriptname=$(basename $0)
-        echo "Usage: $scriptname APP APPARGS"
-        echo "APP is one of the following:"
-        echo "$applications"
-        exit 1
-    fi
-
-    # only APP arguments
-    shift
+    applications=$(find "$PYSUPSICTRL/BlockEditor" -name "*.py" -execdir basename {} \; | sed s/.py//)
+    scriptname="$(basename $0)"
+    echo "Usage: $scriptname APP APPARGS"
+    echo "APP is one of the following:"
+    echo "$applications"
+    exit 1
 fi
 
 if [ -n "$PYTHONPATH" ] ; then


### PR DESCRIPTION
- CodeGen/nuttx: more precise check if standalone ELF should be build
  - Both templates, nuttx.tmf and nuttx_timehook.tmf, are updated including some more minor cleanups.
- CodeGen/nuttx: do not build SPI devices when CONFIG_SPI_EXCHANGE/SPIIOC_TRANSFER is missing
- CodeGen/nuttx: fix build when NuttX CAN supports extended ID
  - When CONFIG_CAN_EXTID is set then extended ID flag should be filled (value defined) for sent messages even that there is  no support to define if ID is extended in sendMsg API.  The "extended" variable declaration has been missing.   It is now set to send all messages with standard ID.
- pysim-run.sh: fix/allow passing of path of a block diagram as the only parameter
  - Some cleanup added as well. The find is called only if incorrect/unknown command is specified.

