### PR TITLE
CodeGen TCPAsync Block: downsampling factor

### DIFF
--- a/CodeGen/Common/posix/TCPsocketAsync.c
+++ b/CodeGen/Common/posix/TCPsocketAsync.c
@@ -301,6 +301,14 @@ static void inout(python_block *block)
   int i;    
   tcp_txrx_state_t *txrxst = (tcp_txrx_state_t *)block->ptrPar;
 
+  /* Downsampling */
+
+  if (++block->intPar[4] < block->intPar[3])
+    {
+      return;
+    }
+  block->intPar[4] = 0;
+
   if (block->nin > 0)
     {
       if (tcp_dqf_free(txrxst) < block->nin)

--- a/resources/blocks/blocks/Communication/TCPsocketAsyncBlk.xblk
+++ b/resources/blocks/blocks/Communication/TCPsocketAsyncBlk.xblk
@@ -6,6 +6,6 @@
   "stin": 1,
   "stout": 1,
   "icon": "TCPSOCKET",
-  "params": "TCPsocketAsyncBlk|IP Addr:'127.0.0.1'|Port:1024:int|Buffer Size:32:int",
-  "help": "This block implements an asynchronous TCP sender and optional receiver\nThis block keep a real time capabilities as send and receive is done in a separate thread from the main application.\nParameters\nIP address of the receiver\nPort\nBuffer size of send buffer\n"
+  "params": "TCPsocketAsyncBlk|IP Addr:'127.0.0.1'|Port:1024:int|Buffer Size:32:int|Downsampling factor:1:int",
+  "help": "This block implements an asynchronous TCP sender and optional receiver\nThis block keep a real time capabilities as send and receive is done in a separate thread from the main application.\nParameters\nIP address of the receiver\nPort\nBuffer size of send buffer\nDownsampling factor: data is sent/received only per xth sample.\n"
 }

--- a/resources/blocks/rcpBlk/Communication/TCPsocketAsyncBlk.py
+++ b/resources/blocks/rcpBlk/Communication/TCPsocketAsyncBlk.py
@@ -2,11 +2,11 @@
 from supsisim.RCPblk import RCPblk
 
 def TCPsocketAsyncBlk(*args):
-    if len(args) == 5:
-        pin, pout, IP, port, buffer = args
-    elif len(args) == 4:
+    if len(args) == 6:
+        pin, pout, IP, port, buffer, downsampling = args
+    elif len(args) == 5:
         pout = []
-        pin, IP, port, buffer = args
+        pin, IP, port, buffer, downsampling = args
 
     """
 
@@ -14,11 +14,12 @@ def TCPsocketAsyncBlk(*args):
 
     Parameters
     ----------
-       pin: connected input port(s)
-       pout: connected output port(s)
-       IP : IP Addr
-       port :  Port
-       buffer : size of send buffer
+       pin          : connected input port(s)
+       pout         : connected output port(s)
+       IP           : IP Addr
+       port         : Port
+       buffer       : size of send buffer
+       downsampling : data is sent/received only per xth sample
 
     Returns
     -------
@@ -26,7 +27,11 @@ def TCPsocketAsyncBlk(*args):
 
     """
 
-    blk = RCPblk('TCPsocketAsync', pin, pout, [0,0], 1, [], [port, buffer, 0], IP)
+    if downsampling < 1:
+        raise ValueError("The downsampling ratio must be greater than zero!")
+
+    # the current sample value must be included with the downsampling value
+    blk = RCPblk('TCPsocketAsync', pin, pout, [0,0], 1, [], [port, buffer, 0, downsampling, 0], IP)
     return blk
 
 


### PR DESCRIPTION
The block enqueues data only per xth sample. 
I've spotted the block does not behave correctly when too much data is enqueued on NuttX as it lead to TCP/IP stack total corruption (somehow?). This downsampling (decimation) field solved this problem.

In reality, for occasional logging purposes, sending fewer data is sufficient.