### PR TITLE
supsisim/shv/client.py: support pyshv versions >=0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pyqtgraph>=0.11.0 # MIT
 lxml>=4.6.3 # BSD License
 tornado>=6.1 #  Apache Software License 2.0
 scikit-build>=0.15.0 # MIT
-pyshv>=0.7.2 #MIT
+pyshv>=0.8.0 #MIT


### PR DESCRIPTION
`pyshv` version 0.8.0 has an incompatible change, `SimpleClient` is renamed to `SHVClient`. We still want to support older `pyshv` version because 0.8.0 requires Python 3.11 that might not be available in all distributions now.

This change allows to run pysimCoder and its SHV capabilities with both pyshv 0.8.0 and older versions.

Closes #106 