### PR TITLE
.github: add continuous integration tests for Linux blocks

### DIFF
--- a/.github/workflows/.blocks.yml
+++ b/.github/workflows/.blocks.yml
@@ -1,0 +1,34 @@
+name: Build Blocks
+
+on: [ push, pull_request ]
+
+jobs:
+  build-linux:
+    name: "Ubuntu Latest"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: "sudo apt-get update && sudo apt-get install libgsl-dev
+              libxml2-dev libxslt1-dev libopenblas-dev libcomedi-dev
+              gcc-arm-linux-gnueabihf"
+
+      - name: "Export PYSUPSICTRL"
+        run: "export PYSUPSICTRL=${{ github.workspace }}"
+
+      - name: LinuxRT
+        run: "make full_lib"
+
+      - name: Linux MZ APO
+        run: "make linux_mzapo"
+
+      - name: Arduino Firmata
+        run: "make arduino_firmata"
+
+      - name: LinuxRT with SHV
+        run: "make full_lib SHV=1"
+
+      - name: Linux MZ APO with SHV
+        run: "make linux_mzapo SHV=1"
+

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ lib:
 full_lib:
 	cd CodeGen/LinuxRT/devices; make all
 
+linux_mzapo:
+	cd CodeGen/linux_mz_apo/devices; make all
+
 arduino_firmata:
 	cd CodeGen/arduinoFirmata; make all
 


### PR DESCRIPTION
This adds continuous integration tests for LinuxRT, Linux MZ APO and Arduino Firmata target's blocks. The build is tested on ubuntu-latest.

This is a naive attempt, I don't have much experience with GitHub actions, but I think this is good enough kick off. We get Linux and Arduino blocks compilation + all common blocks compilation + SHV part of the code tested.