### PR TITLE
FmuBlk.py: fix argument count check

### DIFF
--- a/resources/blocks/rcpBlk/nonlin/FmuBlk.py
+++ b/resources/blocks/rcpBlk/nonlin/FmuBlk.py
@@ -19,9 +19,9 @@ def getXMLindex(file, ref):
 
 
 def FmuBlk(*args):
-    if len(args) == 8:
+    if len(args) == 3:
         pin, pout, params = args
-    elif len(args) == 7:
+    elif len(args) == 2:
         pout, params = args
         pin = []
     else:


### PR DESCRIPTION
The check was a relict for old block format and not valid for new format, where parameters are passed as one class.