### PR TITLE
CodeGen/shv: increment rid in the send_ping function after the for loop

### DIFF
--- a/CodeGen/Common/shv/shv_com.c
+++ b/CodeGen/Common/shv/shv_com.c
@@ -718,12 +718,12 @@ void shv_send_ping(shv_con_ctx_t *shv_ctx)
 
       shv_pack_head_request(shv_ctx, "ping", ".broker/app");
 
-      shv_ctx->rid += 1;
-
       cchainpack_pack_imap_begin(&shv_ctx->pack_ctx);
       cchainpack_pack_container_end(&shv_ctx->pack_ctx);
       shv_overflow_handler(&shv_ctx->pack_ctx, 0);
     }
+
+  shv_ctx->rid += 1;
 }
 
 /****************************************************************************


### PR DESCRIPTION
This was potentially a source of disconnect reasons as the data was packed in a bad way.

This is only a temporary fix. The more stable implementation of the new silicon-heaven library is located here: https://github.com/silicon-heaven/shv-libs4c. The plan is to use this library in near future.